### PR TITLE
パッシブモードを実装

### DIFF
--- a/src/main/java/logbook/internal/proxy/PassiveModeServlet.java
+++ b/src/main/java/logbook/internal/proxy/PassiveModeServlet.java
@@ -114,9 +114,14 @@ public final class PassiveModeServlet extends HttpServlet {
         private ResponseMetaDataWrapper createResponseMetaDataWrapper(HttpServletRequest req) throws IOException {
             ResponseMetaDataWrapper wrapper = new ResponseMetaDataWrapper();
 
-            wrapper.setStatus(200); // Listenerで見てないから200固定でええやろ
-            wrapper.setContentType(req.getContentType()); // Request BodyのContent-Typeそのまま
+            // Listenerで見てないから200固定にしておく
+            wrapper.setStatus(200);
+            // Request BodyのContent-Typeそのまま
+            wrapper.setContentType(req.getContentType());
 
+            // Request Bodyのデータを取得
+            // inputをそのままsetすると、"java.io.IOException: mark/reset not supported" が発生するので
+            // 一度bytes[]に読み込んでからsetする
             InputStream input = req.getInputStream();
             ByteArrayOutputStream baos = new ByteArrayOutputStream();
             byte[] buffer = new byte[1024];
@@ -125,7 +130,8 @@ public final class PassiveModeServlet extends HttpServlet {
                 baos.write(buffer, 0, len);
             }
             baos.flush();
-            wrapper.setResponseBody(Optional.of(new ByteArrayInputStream(baos.toByteArray())));
+            // Content-Encoding: gzipの場合はset()内で自動的に展開される
+            wrapper.set(new ByteArrayInputStream(baos.toByteArray()));
 
             return wrapper;
         }

--- a/src/main/java/logbook/internal/proxy/PassiveModeServlet.java
+++ b/src/main/java/logbook/internal/proxy/PassiveModeServlet.java
@@ -1,0 +1,151 @@
+package logbook.internal.proxy;
+
+import logbook.internal.LoggerHolder;
+import logbook.internal.ThreadManager;
+import logbook.internal.proxy.ReverseProxyServlet.RequestMetaDataWrapper;
+import logbook.internal.proxy.ReverseProxyServlet.ResponseMetaDataWrapper;
+import logbook.plugin.PluginServices;
+import logbook.proxy.ContentListenerSpi;
+
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+/**
+ * 外部からのHTTP POSTリクエストを受け付けてListenerを呼び出すサーブレット
+ * mitmproxy のようなSSL/TLS証明書をサポートするプロキシがフックしたデータをこちらに送信することを想定している
+ */
+public final class PassiveModeServlet extends HttpServlet {
+    private static final long serialVersionUID = 1398734900463655319L;
+
+    public static final String PATH_SPEC = "/pasv/*";
+    private static final String PATH_PREFIX = "/pasv/";
+
+    private static final String REQUEST_METHOD_HEADER = "X-Pasv-Request-Method";
+    private static final String REQUEST_CONTENT_TYPE_HEADER = "X-Pasv-Request-Content-Type";
+    private static final String REQUEST_BODY_HEADER = "X-Pasv-Request-Body";
+
+    /**
+     * リスナー
+     */
+    private transient List<ContentListenerSpi> listeners = null;
+
+    @Override
+    protected void doPost(HttpServletRequest req, HttpServletResponse resp) throws IOException {
+        RequestParsingResult result = new RequestParser().parse(req);
+
+        if (this.invoke(result.getRequestMetaDataWrapper(), result.getResponseMetaDataWrapper())) {
+            resp.setStatus(200);
+            resp.setContentType("text/plain; charset=UTF-8");
+            resp.getWriter().println("OK");
+        } else {
+            resp.sendError(500);
+        }
+    }
+
+    private boolean invoke(RequestMetaDataWrapper req, ResponseMetaDataWrapper res) {
+        try {
+            if (this.listeners == null) {
+                this.listeners = PluginServices.instances(ContentListenerSpi.class).collect(Collectors.toList());
+            }
+            for (ContentListenerSpi listener : this.listeners) {
+                if (listener.test(req)) {
+                    Runnable task = () -> {
+                        try {
+                            listener.accept(req, res);
+                        } catch (Exception e) {
+                            LoggerHolder.get().warn("パッシブモード サーブレットで例外が発生", e);
+                        }
+                    };
+                    ThreadManager.getExecutorService().submit(task);
+                }
+            }
+            return true;
+        } catch (Exception e) {
+            LoggerHolder.get().warn("パッシブモード サーブレットで例外が発生 req=" + req.getRequestURI(), e);
+            return false;
+        }
+    }
+
+    static final class RequestParser {
+        RequestParser() {
+        }
+
+        RequestParsingResult parse(HttpServletRequest req) throws IOException {
+            return new RequestParsingResult(this.createRequestMetaDataWrapper(req), this.createResponseMetaDataWrapper(req));
+        }
+
+        private RequestMetaDataWrapper createRequestMetaDataWrapper(HttpServletRequest req) {
+            RequestMetaDataWrapper wrapper = new RequestMetaDataWrapper();
+
+            wrapper.setContentType(req.getHeader(REQUEST_CONTENT_TYPE_HEADER));
+            wrapper.setMethod(req.getHeader(REQUEST_METHOD_HEADER));
+            wrapper.setQueryString(req.getQueryString());
+
+            String requestUri = req.getRequestURI();
+            if (requestUri.startsWith(PATH_PREFIX)) {
+                wrapper.setRequestURI(requestUri.substring(PATH_PREFIX.length()-1));
+            } else {
+                wrapper.setRequestURI(requestUri);
+            }
+
+            String b64body = req.getHeader(REQUEST_BODY_HEADER);
+            if (b64body != null) {
+                byte[] body = Base64.getDecoder().decode(b64body);
+                wrapper.set(new ByteArrayInputStream(body));
+            } else {
+                // set(InputStream body) をスキップして直接に空のデータをセット
+                wrapper.setParameterMap(new HashMap<>());
+                wrapper.setRequestBody(Optional.empty());
+            }
+
+            return wrapper;
+        }
+
+        private ResponseMetaDataWrapper createResponseMetaDataWrapper(HttpServletRequest req) throws IOException {
+            ResponseMetaDataWrapper wrapper = new ResponseMetaDataWrapper();
+
+            wrapper.setStatus(200); // Listenerで見てないから200固定でええやろ
+            wrapper.setContentType(req.getContentType()); // Request BodyのContent-Typeそのまま
+
+            InputStream input = req.getInputStream();
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            byte[] buffer = new byte[1024];
+            int len;
+            while ((len = input.read(buffer)) > -1) {
+                baos.write(buffer, 0, len);
+            }
+            baos.flush();
+            wrapper.setResponseBody(Optional.of(new ByteArrayInputStream(baos.toByteArray())));
+
+            return wrapper;
+        }
+    }
+
+    static final class RequestParsingResult {
+        private final RequestMetaDataWrapper req;
+        private final ResponseMetaDataWrapper res;
+
+        RequestParsingResult(RequestMetaDataWrapper req, ResponseMetaDataWrapper res) {
+            this.req = req;
+            this.res = res;
+        }
+
+        RequestMetaDataWrapper getRequestMetaDataWrapper() {
+            return this.req;
+        }
+
+        ResponseMetaDataWrapper getResponseMetaDataWrapper() {
+            return this.res;
+        }
+    }
+}

--- a/src/main/java/logbook/internal/proxy/ProxyServerImpl.java
+++ b/src/main/java/logbook/internal/proxy/ProxyServerImpl.java
@@ -55,6 +55,13 @@ public final class ProxyServerImpl implements ProxyServerSpi {
             holder.setInitParameter("maxThreads", "256");
             holder.setInitParameter("timeout", "600000");
             context.addServlet(holder, "/*");
+
+            // パッシブモードのハンドラをセット
+            ServletHolder passive = new ServletHolder(new PassiveModeServlet());
+            passive.setInitParameter("maxThreads", "128");
+            passive.setInitParameter("timeout", "300000");
+            context.addServlet(passive, PassiveModeServlet.PATH_SPEC);
+
             try {
                 try {
                     this.server.start();


### PR DESCRIPTION
## 変更内容

HTTPプロキシとしてではなく、外部からHTTP POSTで送信されたデータによって状態を更新できるようにする。
リクエスト仕様は下記の通り。

### URL

```
http://{host}:{port}/pasv/{original_uri}
```

| パラメータ | 説明 |
|--------------|------|
| host | logbook-kaiのホスト名 |
| port | logbook-kaiのポート番号 |
| original_uri | フックしたリクエストのURI (パスとクエリ) |

#### 例

```
http://127.0.0.1:8888/pasv/kcsapi/api_port/port
```

### Heaers

Javaでmultipart/form-dataの処理をするのが面倒だったので元のリクエスト/レスポンスに関わる情報はHTTPヘッダに含める。

| ヘッダ名 | 説明 |
|------------|------|
| Content-Type | 元のレスポンスのContent-Typeヘッダの値 |
| Content-Encoding | 元のレスポンスのContent-Encodingヘッダの値 (optional) |
| X-Pasv-Request-Method | 元のリクエストのHTTP メソッド |
| X-Pasv-Request-Content-Type | 元のリクエストのContent-Typeヘッダの値 (optional) |
| X-Pasv-Request-Body | 元のリクエストのボディをBase64エンコードしたもの (optional)<br>APIリクエストパラメータ解析するのに必要 |

#### 例

```
Content-Type: text/plain
Content-Encoding: gzip
X-Pasv-Request-Method: POST
X-Pasv-Request-Content-Type: application/www-form-urlencoded
X-Pasv-Request-Body: AAAAAAAAAAAAAAAAAAAAAAAA
```


### Body

取得した生のレスポンスボディをそのまま。

## 関連するIssue

N/A

