### PR TITLE
v24.3.1

### DIFF
--- a/pom-java17.xml
+++ b/pom-java17.xml
@@ -4,7 +4,7 @@
     <name>logbook-kai</name>
     <artifactId>logbook-kai-java17</artifactId>
     <groupId>logbook</groupId>
-    <version>23.9.1</version>
+    <version>24.3.1</version>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <name>logbook-kai</name>
     <artifactId>logbook-kai</artifactId>
     <groupId>logbook</groupId>
-    <version>23.9.1</version>
+    <version>24.3.1</version>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>1.8</java.version>

--- a/src/main/java/logbook/bean/AppConfig.java
+++ b/src/main/java/logbook/bean/AppConfig.java
@@ -20,7 +20,7 @@ import lombok.Data;
 @Data
 public final class AppConfig implements Serializable {
 
-    private static final long serialVersionUID = -4212969150927105963L;
+    private static final long serialVersionUID = -801833078377154688L;
 
     /** ウインドウスタイル */
     private String windowStyle = "main";
@@ -147,6 +147,9 @@ public final class AppConfig implements Serializable {
 
     /** プロキシポート */
     private int proxyPort = 8080;
+
+    /** パッシブモードを有効にする */
+    private boolean usePassiveMode = false;
 
     /** プラグインを有効にする */
     private boolean usePlugin = true;

--- a/src/main/java/logbook/bean/AppConfig.java
+++ b/src/main/java/logbook/bean/AppConfig.java
@@ -20,7 +20,7 @@ import lombok.Data;
 @Data
 public final class AppConfig implements Serializable {
 
-    private static final long serialVersionUID = -158061123666406172L;
+    private static final long serialVersionUID = -4212969150927105963L;
 
     /** ウインドウスタイル */
     private String windowStyle = "main";
@@ -132,9 +132,6 @@ public final class AppConfig implements Serializable {
 
     /** 起動時にアップデートチェック */
     private boolean checkUpdate = true;
-
-    /** 通信エラーの抑止 */
-    private boolean connectionClose = true;
 
     /** ポート番号 */
     private int listenPort = 8888;

--- a/src/main/java/logbook/bean/BattleMidnightBattle.java
+++ b/src/main/java/logbook/bean/BattleMidnightBattle.java
@@ -16,7 +16,7 @@ import lombok.Data;
 @Data
 public class BattleMidnightBattle implements IMidnightBattle, Serializable {
 
-    private static final long serialVersionUID = 1993839270894519690L;
+    private static final long serialVersionUID = 4437518963527152795L;
 
     /** api_dock_id/api_deck_id */
     private Integer dockId;
@@ -63,6 +63,16 @@ public class BattleMidnightBattle implements IMidnightBattle, Serializable {
     /** api_hougeki */
     private BattleTypes.MidnightHougeki hougeki;
 
+
+    /** api_smoke_type */
+    private Integer smokeType;
+
+    /** api_balloon_cell */
+    private Integer balloonCell;
+
+    /** api_atoll_cell */
+    private Integer atollCell;
+
     /**
      * JsonObjectから{@link BattleMidnightBattle}を構築します
      *
@@ -87,7 +97,10 @@ public class BattleMidnightBattle implements IMidnightBattle, Serializable {
                 .set("api_friendly_battle", bean::setFriendlyBattle, BattleTypes.FriendlyBattle::toFriendlyBattle)
                 .setIntegerList("api_touch_plane", bean::setTouchPlane)
                 .setIntegerList("api_flare_pos", bean::setFlarePos)
-                .set("api_hougeki", bean::setHougeki, BattleTypes.MidnightHougeki::toMidnightHougeki);
+                .set("api_hougeki", bean::setHougeki, BattleTypes.MidnightHougeki::toMidnightHougeki)
+                .setInteger("api_smoke_type", bean::setSmokeType)
+                .setInteger("api_balloon_cell", bean::setBalloonCell)
+                .setInteger("api_atoll_cell", bean::setAtollCell);
         return bean;
     }
 }

--- a/src/main/java/logbook/bean/BattleMidnightSpMidnight.java
+++ b/src/main/java/logbook/bean/BattleMidnightSpMidnight.java
@@ -18,7 +18,7 @@ import lombok.Data;
 @Data
 public class BattleMidnightSpMidnight implements IMidnightBattle, IFormation, INSupport, Serializable {
 
-    private static final long serialVersionUID = 1948191471496244360L;
+    private static final long serialVersionUID = -7565628040554842146L;
 
     /** api_dock_id/api_deck_id */
     private Integer dockId;
@@ -74,6 +74,15 @@ public class BattleMidnightSpMidnight implements IMidnightBattle, IFormation, IN
     /** api_n_support_info */
     private BattleTypes.SupportInfo nSupportInfo;
 
+    /** api_smoke_type */
+    private Integer smokeType;
+
+    /** api_balloon_cell */
+    private Integer balloonCell;
+
+    /** api_atoll_cell */
+    private Integer atollCell;
+
     /**
      * JsonObjectから{@link BattleMidnightSpMidnight}を構築します
      *
@@ -101,7 +110,10 @@ public class BattleMidnightSpMidnight implements IMidnightBattle, IFormation, IN
                 .setIntegerList("api_flare_pos", bean::setFlarePos)
                 .set("api_hougeki", bean::setHougeki, BattleTypes.MidnightHougeki::toMidnightHougeki)
                 .setInteger("api_n_support_flag", bean::setNSupportFlag)
-                .set("api_n_support_info", bean::setNSupportInfo, BattleTypes.SupportInfo::toSupportInfo);
+                .set("api_n_support_info", bean::setNSupportInfo, BattleTypes.SupportInfo::toSupportInfo)
+                .setInteger("api_smoke_type", bean::setSmokeType)
+                .setInteger("api_balloon_cell", bean::setBalloonCell)
+                .setInteger("api_atoll_cell", bean::setAtollCell);
         return bean;
     }
 }

--- a/src/main/java/logbook/bean/BattleTypes.java
+++ b/src/main/java/logbook/bean/BattleTypes.java
@@ -394,7 +394,7 @@ public class BattleTypes {
          * api_opening_atackを取得します。
          * @return api_opening_atack
          */
-        BattleTypes.Raigeki getOpeningAtack();
+        BattleTypes.OpeningAtack getOpeningAtack();
 
         /**
          * api_opening_taisen_flagを取得します。
@@ -1109,6 +1109,58 @@ public class BattleTypes {
                     .setIntegerList("api_undressing_flag", bean::setUndressingFlag)
                     .setIntegerList("api_cl_list", bean::setClList)
                     .setDoubleList("api_damage", bean::setDamage);
+            return bean;
+        }
+    }
+
+    /**
+     * 開幕
+     */
+    @Data
+    public static class OpeningAtack implements Serializable {
+        private static final long serialVersionUID = 5826255800868507590L;
+
+        /** api_frai_list_items */
+        private List<List<Integer>> fraiListItems;
+
+        /** api_fcl_list_items */
+        private List<List<Integer>> fclListItems;
+
+        /** api_fdam */
+        private List<Double> fdam;
+
+        /** api_fydam_list_items */
+        private List<List<Double>> fydamListItems;
+
+        /** api_erai_list_items */
+        private List<List<Integer>> eraiListItems;
+
+        /** api_ecl_list_items */
+        private List<List<Integer>> eclListItems;
+
+        /** api_edam */
+        private List<Double> edam;
+
+        /** api_eydam_list_items */
+        private List<List<Double>> eydamListItems;
+
+        /**
+         * JsonObjectから{@link OpeningAtack}を構築します
+         *
+         * @param json JsonObject
+         * @return {@link OpeningAtack}
+         */
+        public static OpeningAtack toOpeningAtack(JsonObject json) {
+            OpeningAtack bean = new OpeningAtack();
+            JsonHelper.bind(json)
+                    .set("api_frai_list_items", bean::setFraiListItems, JsonHelper.toList(JsonHelper::checkedToIntegerList))
+                    .set("api_fcl_list_items", bean::setFclListItems, JsonHelper.toList(JsonHelper::checkedToIntegerList))
+                    .setDoubleList("api_fdam", bean::setFdam)
+                    .set("api_fydam_list_items", bean::setFydamListItems, JsonHelper.toList(JsonHelper::checkedToDoubleList))
+                    .set("api_erai_list_items", bean::setEraiListItems, JsonHelper.toList(JsonHelper::checkedToIntegerList))
+                    .set("api_ecl_list_items", bean::setEclListItems, JsonHelper.toList(JsonHelper::checkedToIntegerList))
+                    .setDoubleList("api_edam", bean::setEdam)
+                    .set("api_eydam_list_items", bean::setEydamListItems, JsonHelper.toList(JsonHelper::checkedToDoubleList));
             return bean;
         }
     }

--- a/src/main/java/logbook/bean/BattleTypes.java
+++ b/src/main/java/logbook/bean/BattleTypes.java
@@ -86,6 +86,24 @@ public class BattleTypes {
          */
         List<List<Integer>> getEParam();
 
+        /**
+         * api_smoke_typeを取得します。
+         * @return api_smoke_type
+         */
+        Integer getSmokeType();
+
+        /**
+         * api_balloon_cellを取得します。
+         * @return api_balloon_cell
+         */
+        Integer getBalloonCell();
+
+        /**
+         * api_atoll_cellを取得します。
+         * @return api_atoll_cell
+         */
+
+
         @JsonIgnore
         default boolean isIAirBaseAttack() {
             return false;

--- a/src/main/java/logbook/bean/CombinedBattleAirbattle.java
+++ b/src/main/java/logbook/bean/CombinedBattleAirbattle.java
@@ -22,7 +22,7 @@ import lombok.Data;
 public class CombinedBattleAirbattle
         implements ICombinedBattle, ISortieBattle, IFormation, IAirbattle, ISupport, IAirBaseAttack, Serializable {
 
-    private static final long serialVersionUID = 5422374810830868549L;
+    private static final long serialVersionUID = -2468240522077159945L;
 
     /** api_air_base_injection */
     private BattleTypes.AirBaseAttack airBaseInjection;
@@ -99,6 +99,15 @@ public class CombinedBattleAirbattle
     /** api_kouku2 */
     private BattleTypes.Kouku kouku2;
 
+    /** api_smoke_type */
+    private Integer smokeType;
+
+    /** api_balloon_cell */
+    private Integer balloonCell;
+
+    /** api_atoll_cell */
+    private Integer atollCell;
+
     /**
      * JsonObjectから{@link CombinedBattleAirbattle}を構築します
      *
@@ -135,7 +144,10 @@ public class CombinedBattleAirbattle
                 .setInteger("api_support_flag", bean::setSupportFlag)
                 .set("api_support_info", bean::setSupportInfo, BattleTypes.SupportInfo::toSupportInfo)
                 .setIntegerList("api_stage_flag2", bean::setStageFlag2)
-                .set("api_kouku2", bean::setKouku2, BattleTypes.Kouku::toKouku);
+                .set("api_kouku2", bean::setKouku2, BattleTypes.Kouku::toKouku)
+                .setInteger("api_smoke_type", bean::setSmokeType)
+                .setInteger("api_balloon_cell", bean::setBalloonCell)
+                .setInteger("api_atoll_cell", bean::setAtollCell);
         return bean;
     }
 }

--- a/src/main/java/logbook/bean/CombinedBattleBattle.java
+++ b/src/main/java/logbook/bean/CombinedBattleBattle.java
@@ -98,7 +98,7 @@ public class CombinedBattleBattle implements ICombinedBattle, ISortieBattle, ISo
     private Boolean openingFlag;
 
     /** api_opening_atack */
-    private BattleTypes.Raigeki openingAtack;
+    private BattleTypes.OpeningAtack openingAtack;
 
     /** api_opening_taisen_flag */
     private Boolean openingTaisenFlag;
@@ -157,7 +157,7 @@ public class CombinedBattleBattle implements ICombinedBattle, ISortieBattle, ISo
                 .setInteger("api_support_flag", bean::setSupportFlag)
                 .set("api_support_info", bean::setSupportInfo, BattleTypes.SupportInfo::toSupportInfo)
                 .setBoolean("api_opening_flag", bean::setOpeningFlag)
-                .set("api_opening_atack", bean::setOpeningAtack, BattleTypes.Raigeki::toRaigeki)
+                .set("api_opening_atack", bean::setOpeningAtack, BattleTypes.OpeningAtack::toOpeningAtack)
                 .setBoolean("api_opening_taisen_flag", bean::setOpeningTaisenFlag)
                 .set("api_opening_taisen", bean::setOpeningTaisen, BattleTypes.Hougeki::toHougeki)
                 .setIntegerList("api_hourai_flag", bean::setHouraiFlag)

--- a/src/main/java/logbook/bean/CombinedBattleBattle.java
+++ b/src/main/java/logbook/bean/CombinedBattleBattle.java
@@ -23,7 +23,7 @@ import lombok.Data;
 public class CombinedBattleBattle implements ICombinedBattle, ISortieBattle, ISortieHougeki, IFormation, IKouku,
         ISupport, IAirBaseAttack, Serializable {
 
-    private static final long serialVersionUID = 1636245765528487955L;
+    private static final long serialVersionUID = -7528447192382201636L;
 
     /** api_air_base_injection */
     private BattleTypes.AirBaseAttack airBaseInjection;
@@ -121,6 +121,15 @@ public class CombinedBattleBattle implements ICombinedBattle, ISortieBattle, ISo
     /** api_hougeki3 */
     private BattleTypes.Hougeki hougeki3;
 
+    /** api_smoke_type */
+    private Integer smokeType;
+
+    /** api_balloon_cell */
+    private Integer balloonCell;
+
+    /** api_atoll_cell */
+    private Integer atollCell;
+
     /**
      * JsonObjectから{@link CombinedBattleBattle}を構築します
      *
@@ -164,7 +173,10 @@ public class CombinedBattleBattle implements ICombinedBattle, ISortieBattle, ISo
                 .set("api_hougeki1", bean::setHougeki1, BattleTypes.Hougeki::toHougeki)
                 .set("api_raigeki", bean::setRaigeki, BattleTypes.Raigeki::toRaigeki)
                 .set("api_hougeki2", bean::setHougeki2, BattleTypes.Hougeki::toHougeki)
-                .set("api_hougeki3", bean::setHougeki3, BattleTypes.Hougeki::toHougeki);
+                .set("api_hougeki3", bean::setHougeki3, BattleTypes.Hougeki::toHougeki)
+                .setInteger("api_smoke_type", bean::setSmokeType)
+                .setInteger("api_balloon_cell", bean::setBalloonCell)
+                .setInteger("api_atoll_cell", bean::setAtollCell);
         return bean;
     }
 }

--- a/src/main/java/logbook/bean/CombinedBattleBattleWater.java
+++ b/src/main/java/logbook/bean/CombinedBattleBattleWater.java
@@ -98,7 +98,7 @@ public class CombinedBattleBattleWater implements ICombinedBattle, ISortieBattle
     private Boolean openingFlag;
 
     /** api_opening_atack */
-    private BattleTypes.Raigeki openingAtack;
+    private BattleTypes.OpeningAtack openingAtack;
 
     /** api_opening_taisen_flag */
     private Boolean openingTaisenFlag;
@@ -157,7 +157,7 @@ public class CombinedBattleBattleWater implements ICombinedBattle, ISortieBattle
                 .setInteger("api_support_flag", bean::setSupportFlag)
                 .set("api_support_info", bean::setSupportInfo, BattleTypes.SupportInfo::toSupportInfo)
                 .setBoolean("api_opening_flag", bean::setOpeningFlag)
-                .set("api_opening_atack", bean::setOpeningAtack, BattleTypes.Raigeki::toRaigeki)
+                .set("api_opening_atack", bean::setOpeningAtack, BattleTypes.OpeningAtack::toOpeningAtack)
                 .setBoolean("api_opening_taisen_flag", bean::setOpeningTaisenFlag)
                 .set("api_opening_taisen", bean::setOpeningTaisen, BattleTypes.Hougeki::toHougeki)
                 .setIntegerList("api_hourai_flag", bean::setHouraiFlag)

--- a/src/main/java/logbook/bean/CombinedBattleBattleWater.java
+++ b/src/main/java/logbook/bean/CombinedBattleBattleWater.java
@@ -23,7 +23,7 @@ import lombok.Data;
 public class CombinedBattleBattleWater implements ICombinedBattle, ISortieBattle, ISortieHougeki, IFormation, IKouku,
         ISupport, IAirBaseAttack, Serializable {
 
-    private static final long serialVersionUID = -6447392433716613671L;
+    private static final long serialVersionUID = 3186533126573393275L;
 
     /** api_air_base_injection */
     private BattleTypes.AirBaseAttack airBaseInjection;
@@ -121,6 +121,15 @@ public class CombinedBattleBattleWater implements ICombinedBattle, ISortieBattle
     /** api_raigeki */
     private BattleTypes.Raigeki raigeki;
 
+    /** api_smoke_type */
+    private Integer smokeType;
+
+    /** api_balloon_cell */
+    private Integer balloonCell;
+
+    /** api_atoll_cell */
+    private Integer atollCell;
+
     /**
      * JsonObjectから{@link CombinedBattleBattleWater}を構築します
      *
@@ -164,7 +173,10 @@ public class CombinedBattleBattleWater implements ICombinedBattle, ISortieBattle
                 .set("api_hougeki1", bean::setHougeki1, BattleTypes.Hougeki::toHougeki)
                 .set("api_hougeki2", bean::setHougeki2, BattleTypes.Hougeki::toHougeki)
                 .set("api_hougeki3", bean::setHougeki3, BattleTypes.Hougeki::toHougeki)
-                .set("api_raigeki", bean::setRaigeki, BattleTypes.Raigeki::toRaigeki);
+                .set("api_raigeki", bean::setRaigeki, BattleTypes.Raigeki::toRaigeki)
+                .setInteger("api_smoke_type", bean::setSmokeType)
+                .setInteger("api_balloon_cell", bean::setBalloonCell)
+                .setInteger("api_atoll_cell", bean::setAtollCell);
         return bean;
     }
 }

--- a/src/main/java/logbook/bean/CombinedBattleEachBattle.java
+++ b/src/main/java/logbook/bean/CombinedBattleEachBattle.java
@@ -24,7 +24,7 @@ import lombok.Data;
 public class CombinedBattleEachBattle implements ICombinedBattle, ICombinedEcBattle,
         ISortieBattle, ISortieHougeki, IFormation, IKouku, ISupport, IAirBaseAttack, Serializable {
 
-    private static final long serialVersionUID = 5915335230012435843L;
+    private static final long serialVersionUID = -2452196810216671853L;
 
     /** api_air_base_injection */
     private BattleTypes.AirBaseAttack airBaseInjection;
@@ -140,6 +140,15 @@ public class CombinedBattleEachBattle implements ICombinedBattle, ICombinedEcBat
     /** api_hougeki3 */
     private BattleTypes.Hougeki hougeki3;
 
+    /** api_smoke_type */
+    private Integer smokeType;
+
+    /** api_balloon_cell */
+    private Integer balloonCell;
+
+    /** api_atoll_cell */
+    private Integer atollCell;
+
     /**
      * JsonObjectから{@link CombinedBattleEachBattle}を構築します
      *
@@ -189,7 +198,10 @@ public class CombinedBattleEachBattle implements ICombinedBattle, ICombinedEcBat
                 .set("api_hougeki1", bean::setHougeki1, BattleTypes.Hougeki::toHougeki)
                 .set("api_raigeki", bean::setRaigeki, BattleTypes.Raigeki::toRaigeki)
                 .set("api_hougeki2", bean::setHougeki2, BattleTypes.Hougeki::toHougeki)
-                .set("api_hougeki3", bean::setHougeki3, BattleTypes.Hougeki::toHougeki);
+                .set("api_hougeki3", bean::setHougeki3, BattleTypes.Hougeki::toHougeki)
+                .setInteger("api_smoke_type", bean::setSmokeType)
+                .setInteger("api_balloon_cell", bean::setBalloonCell)
+                .setInteger("api_atoll_cell", bean::setAtollCell);
         return bean;
     }
 }

--- a/src/main/java/logbook/bean/CombinedBattleEachBattle.java
+++ b/src/main/java/logbook/bean/CombinedBattleEachBattle.java
@@ -117,7 +117,7 @@ public class CombinedBattleEachBattle implements ICombinedBattle, ICombinedEcBat
     private Boolean openingFlag;
 
     /** api_opening_atack */
-    private BattleTypes.Raigeki openingAtack;
+    private BattleTypes.OpeningAtack openingAtack;
 
     /** api_opening_taisen_flag */
     private Boolean openingTaisenFlag;
@@ -182,7 +182,7 @@ public class CombinedBattleEachBattle implements ICombinedBattle, ICombinedEcBat
                 .setInteger("api_support_flag", bean::setSupportFlag)
                 .set("api_support_info", bean::setSupportInfo, BattleTypes.SupportInfo::toSupportInfo)
                 .setBoolean("api_opening_flag", bean::setOpeningFlag)
-                .set("api_opening_atack", bean::setOpeningAtack, BattleTypes.Raigeki::toRaigeki)
+                .set("api_opening_atack", bean::setOpeningAtack, BattleTypes.OpeningAtack::toOpeningAtack)
                 .setBoolean("api_opening_taisen_flag", bean::setOpeningTaisenFlag)
                 .set("api_opening_taisen", bean::setOpeningTaisen, BattleTypes.Hougeki::toHougeki)
                 .setIntegerList("api_hourai_flag", bean::setHouraiFlag)

--- a/src/main/java/logbook/bean/CombinedBattleEcBattle.java
+++ b/src/main/java/logbook/bean/CombinedBattleEcBattle.java
@@ -23,7 +23,7 @@ import lombok.Data;
 public class CombinedBattleEcBattle implements ICombinedEcBattle, ISortieBattle, ISortieHougeki,
         IFormation, IKouku, ISupport, IAirBaseAttack, Serializable {
 
-    private static final long serialVersionUID = 9219457270531289491L;
+    private static final long serialVersionUID = -1242105892288667128L;
 
     /** api_air_base_injection */
     private BattleTypes.AirBaseAttack airBaseInjection;
@@ -133,6 +133,15 @@ public class CombinedBattleEcBattle implements ICombinedEcBattle, ISortieBattle,
     /** api_raigeki */
     private BattleTypes.Raigeki raigeki;
 
+    /** api_smoke_type */
+    private Integer smokeType;
+
+    /** api_balloon_cell */
+    private Integer balloonCell;
+
+    /** api_atoll_cell */
+    private Integer atollCell;
+
     /**
      * JsonObjectから{@link CombinedBattleEcBattle}を構築します
      *
@@ -180,7 +189,10 @@ public class CombinedBattleEcBattle implements ICombinedEcBattle, ISortieBattle,
                 .set("api_hougeki1", bean::setHougeki1, BattleTypes.Hougeki::toHougeki)
                 .set("api_hougeki2", bean::setHougeki2, BattleTypes.Hougeki::toHougeki)
                 .set("api_hougeki3", bean::setHougeki3, BattleTypes.Hougeki::toHougeki)
-                .set("api_raigeki", bean::setRaigeki, BattleTypes.Raigeki::toRaigeki);
+                .set("api_raigeki", bean::setRaigeki, BattleTypes.Raigeki::toRaigeki)
+                .setInteger("api_smoke_type", bean::setSmokeType)
+                .setInteger("api_balloon_cell", bean::setBalloonCell)
+                .setInteger("api_atoll_cell", bean::setAtollCell);
         return bean;
     }
 }

--- a/src/main/java/logbook/bean/CombinedBattleEcBattle.java
+++ b/src/main/java/logbook/bean/CombinedBattleEcBattle.java
@@ -110,7 +110,7 @@ public class CombinedBattleEcBattle implements ICombinedEcBattle, ISortieBattle,
     private Boolean openingFlag;
 
     /** api_opening_atack */
-    private BattleTypes.Raigeki openingAtack;
+    private BattleTypes.OpeningAtack openingAtack;
 
     /** api_opening_taisen_flag */
     private Boolean openingTaisenFlag;
@@ -173,7 +173,7 @@ public class CombinedBattleEcBattle implements ICombinedEcBattle, ISortieBattle,
                 .setInteger("api_support_flag", bean::setSupportFlag)
                 .set("api_support_info", bean::setSupportInfo, BattleTypes.SupportInfo::toSupportInfo)
                 .setBoolean("api_opening_flag", bean::setOpeningFlag)
-                .set("api_opening_atack", bean::setOpeningAtack, BattleTypes.Raigeki::toRaigeki)
+                .set("api_opening_atack", bean::setOpeningAtack, BattleTypes.OpeningAtack::toOpeningAtack)
                 .setBoolean("api_opening_taisen_flag", bean::setOpeningTaisenFlag)
                 .set("api_opening_taisen", bean::setOpeningTaisen, BattleTypes.Hougeki::toHougeki)
                 .setIntegerList("api_hourai_flag", bean::setHouraiFlag)

--- a/src/main/java/logbook/bean/CombinedBattleEcMidnightBattle.java
+++ b/src/main/java/logbook/bean/CombinedBattleEcMidnightBattle.java
@@ -17,7 +17,7 @@ import lombok.Data;
 @Data
 public class CombinedBattleEcMidnightBattle implements ICombinedEcMidnightBattle, IMidnightBattle, Serializable {
 
-    private static final long serialVersionUID = 8584847683187523584L;
+    private static final long serialVersionUID = -5762686287403000706L;
 
     /** api_active_deck */
     private List<Integer> activeDeck;
@@ -88,6 +88,15 @@ public class CombinedBattleEcMidnightBattle implements ICombinedEcMidnightBattle
     /** api_hougeki */
     private BattleTypes.MidnightHougeki hougeki;
 
+    /** api_smoke_type */
+    private Integer smokeType;
+
+    /** api_balloon_cell */
+    private Integer balloonCell;
+
+    /** api_atoll_cell */
+    private Integer atollCell;
+
     /**
      * JsonObjectから{@link CombinedBattleEcMidnightBattle}を構築します
      *
@@ -119,7 +128,10 @@ public class CombinedBattleEcMidnightBattle implements ICombinedEcMidnightBattle
                 .set("api_friendly_battle", bean::setFriendlyBattle, BattleTypes.FriendlyBattle::toFriendlyBattle)
                 .setIntegerList("api_touch_plane", bean::setTouchPlane)
                 .setIntegerList("api_flare_pos", bean::setFlarePos)
-                .set("api_hougeki", bean::setHougeki, BattleTypes.MidnightHougeki::toMidnightHougeki);
+                .set("api_hougeki", bean::setHougeki, BattleTypes.MidnightHougeki::toMidnightHougeki)
+                .setInteger("api_smoke_type", bean::setSmokeType)
+                .setInteger("api_balloon_cell", bean::setBalloonCell)
+                .setInteger("api_atoll_cell", bean::setAtollCell);
         return bean;
     }
 }

--- a/src/main/java/logbook/bean/CombinedBattleEcNightToDay.java
+++ b/src/main/java/logbook/bean/CombinedBattleEcNightToDay.java
@@ -142,7 +142,7 @@ public class CombinedBattleEcNightToDay implements ICombinedBattle, ICombinedEcB
     private Boolean openingFlag;
 
     /** api_opening_atack */
-    private BattleTypes.Raigeki openingAtack;
+    private BattleTypes.OpeningAtack openingAtack;
 
     /** api_hourai_flag */
     private List<Integer> houraiFlag;
@@ -211,7 +211,7 @@ public class CombinedBattleEcNightToDay implements ICombinedBattle, ICombinedEcB
                 .setBoolean("api_opening_taisen_flag", bean::setOpeningTaisenFlag)
                 .set("api_opening_taisen", bean::setOpeningTaisen, BattleTypes.Hougeki::toHougeki)
                 .setBoolean("api_opening_flag", bean::setOpeningFlag)
-                .set("api_opening_atack", bean::setOpeningAtack, BattleTypes.Raigeki::toRaigeki)
+                .set("api_opening_atack", bean::setOpeningAtack, BattleTypes.OpeningAtack::toOpeningAtack)
                 .setIntegerList("api_hourai_flag", bean::setHouraiFlag)
                 .set("api_hougeki1", bean::setHougeki1, BattleTypes.Hougeki::toHougeki)
                 .set("api_hougeki2", bean::setHougeki2, BattleTypes.Hougeki::toHougeki)

--- a/src/main/java/logbook/bean/CombinedBattleEcNightToDay.java
+++ b/src/main/java/logbook/bean/CombinedBattleEcNightToDay.java
@@ -25,7 +25,7 @@ import lombok.Data;
 public class CombinedBattleEcNightToDay implements ICombinedBattle, ICombinedEcBattle, IFormation,
         INightToDayBattle, IAirBaseAttack, IKouku, ISortieHougeki, INSupport, ISupport, Serializable {
 
-    private static final long serialVersionUID = -364877629377359534L;
+    private static final long serialVersionUID = 2039831760623918871L;
 
     /** api_dock_id/api_deck_id */
     private Integer dockId;
@@ -162,6 +162,15 @@ public class CombinedBattleEcNightToDay implements ICombinedBattle, ICombinedEcB
     /** api_midnight_flag(未使用) */
     private Boolean midnightFlag;
 
+    /** api_smoke_type */
+    private Integer smokeType;
+
+    /** api_balloon_cell */
+    private Integer balloonCell;
+
+    /** api_atoll_cell */
+    private Integer atollCell;
+
     /**
      * JsonObjectから{@link CombinedBattleEcNightToDay}を構築します
      *
@@ -216,7 +225,10 @@ public class CombinedBattleEcNightToDay implements ICombinedBattle, ICombinedEcB
                 .set("api_hougeki1", bean::setHougeki1, BattleTypes.Hougeki::toHougeki)
                 .set("api_hougeki2", bean::setHougeki2, BattleTypes.Hougeki::toHougeki)
                 .set("api_hougeki3", bean::setHougeki3, BattleTypes.Hougeki::toHougeki)
-                .set("api_raigeki", bean::setRaigeki, BattleTypes.Raigeki::toRaigeki);
+                .set("api_raigeki", bean::setRaigeki, BattleTypes.Raigeki::toRaigeki)
+                .setInteger("api_smoke_type", bean::setSmokeType)
+                .setInteger("api_balloon_cell", bean::setBalloonCell)
+                .setInteger("api_atoll_cell", bean::setAtollCell);
         return bean;
     }
 }

--- a/src/main/java/logbook/bean/CombinedBattleLdAirbattle.java
+++ b/src/main/java/logbook/bean/CombinedBattleLdAirbattle.java
@@ -22,7 +22,7 @@ import lombok.Data;
 public class CombinedBattleLdAirbattle
         implements ICombinedBattle, ISortieBattle, IFormation, IKouku, IAirBaseAttack, ILdAirbattle, Serializable {
 
-    private static final long serialVersionUID = 6539186077635769896L;
+    private static final long serialVersionUID = 3973220806079496549L;
 
     /** api_air_base_injection */
     private BattleTypes.AirBaseAttack airBaseInjection;
@@ -87,6 +87,15 @@ public class CombinedBattleLdAirbattle
     /** api_kouku */
     private BattleTypes.Kouku kouku;
 
+    /** api_smoke_type */
+    private Integer smokeType;
+
+    /** api_balloon_cell */
+    private Integer balloonCell;
+
+    /** api_atoll_cell */
+    private Integer atollCell;
+
     /**
      * JsonObjectから{@link CombinedBattleLdAirbattle}を構築します
      *
@@ -119,7 +128,10 @@ public class CombinedBattleLdAirbattle
                 .setIntegerList("api_formation", bean::setFormation)
                 .setIntegerList("api_stage_flag", bean::setStageFlag)
                 .set("api_injection_kouku", bean::setInjectionKouku, BattleTypes.Kouku::toKouku)
-                .set("api_kouku", bean::setKouku, BattleTypes.Kouku::toKouku);
+                .set("api_kouku", bean::setKouku, BattleTypes.Kouku::toKouku)
+                .setInteger("api_smoke_type", bean::setSmokeType)
+                .setInteger("api_balloon_cell", bean::setBalloonCell)
+                .setInteger("api_atoll_cell", bean::setAtollCell);
         return bean;
     }
 }

--- a/src/main/java/logbook/bean/CombinedBattleMidnightBattle.java
+++ b/src/main/java/logbook/bean/CombinedBattleMidnightBattle.java
@@ -17,7 +17,7 @@ import lombok.Data;
 @Data
 public class CombinedBattleMidnightBattle implements ICombinedBattle, IMidnightBattle, Serializable {
 
-    private static final long serialVersionUID = 8584847683187523584L;
+    private static final long serialVersionUID = 109139678736593625L;
 
     /** api_dock_id/api_deck_id */
     private Integer dockId;
@@ -73,6 +73,15 @@ public class CombinedBattleMidnightBattle implements ICombinedBattle, IMidnightB
     /** api_hougeki */
     private BattleTypes.MidnightHougeki hougeki;
 
+    /** api_smoke_type */
+    private Integer smokeType;
+
+    /** api_balloon_cell */
+    private Integer balloonCell;
+
+    /** api_atoll_cell */
+    private Integer atollCell;
+
     /**
      * JsonObjectから{@link CombinedBattleMidnightBattle}を構築します
      *
@@ -100,7 +109,10 @@ public class CombinedBattleMidnightBattle implements ICombinedBattle, IMidnightB
                 .set("api_friendly_battle", bean::setFriendlyBattle, BattleTypes.FriendlyBattle::toFriendlyBattle)
                 .setIntegerList("api_touch_plane", bean::setTouchPlane)
                 .setIntegerList("api_flare_pos", bean::setFlarePos)
-                .set("api_hougeki", bean::setHougeki, BattleTypes.MidnightHougeki::toMidnightHougeki);
+                .set("api_hougeki", bean::setHougeki, BattleTypes.MidnightHougeki::toMidnightHougeki)
+                .setInteger("api_smoke_type", bean::setSmokeType)
+                .setInteger("api_balloon_cell", bean::setBalloonCell)
+                .setInteger("api_atoll_cell", bean::setAtollCell);
         return bean;
     }
 }

--- a/src/main/java/logbook/bean/CombinedBattleSpMidnight.java
+++ b/src/main/java/logbook/bean/CombinedBattleSpMidnight.java
@@ -19,7 +19,7 @@ import lombok.Data;
 @Data
 public class CombinedBattleSpMidnight implements ICombinedBattle, IMidnightBattle, IFormation, INSupport, Serializable {
 
-    private static final long serialVersionUID = -364877629377359534L;
+    private static final long serialVersionUID = -4332436044586027210L;
 
     /** api_dock_id/api_deck_id */
     private Integer dockId;
@@ -84,6 +84,15 @@ public class CombinedBattleSpMidnight implements ICombinedBattle, IMidnightBattl
     /** api_n_support_info */
     private BattleTypes.SupportInfo nSupportInfo;
 
+    /** api_smoke_type */
+    private Integer smokeType;
+
+    /** api_balloon_cell */
+    private Integer balloonCell;
+
+    /** api_atoll_cell */
+    private Integer atollCell;
+
     /**
      * JsonObjectから{@link CombinedBattleSpMidnight}を構築します
      *
@@ -114,7 +123,10 @@ public class CombinedBattleSpMidnight implements ICombinedBattle, IMidnightBattl
                 .setIntegerList("api_flare_pos", bean::setFlarePos)
                 .set("api_hougeki", bean::setHougeki, BattleTypes.MidnightHougeki::toMidnightHougeki)
                 .setInteger("api_n_support_flag", bean::setNSupportFlag)
-                .set("api_n_support_info", bean::setNSupportInfo, BattleTypes.SupportInfo::toSupportInfo);
+                .set("api_n_support_info", bean::setNSupportInfo, BattleTypes.SupportInfo::toSupportInfo)
+                .setInteger("api_smoke_type", bean::setSmokeType)
+                .setInteger("api_balloon_cell", bean::setBalloonCell)
+                .setInteger("api_atoll_cell", bean::setAtollCell);
         return bean;
     }
 }

--- a/src/main/java/logbook/bean/SortieAirbattle.java
+++ b/src/main/java/logbook/bean/SortieAirbattle.java
@@ -20,7 +20,7 @@ import lombok.Data;
 @Data
 public class SortieAirbattle implements ISortieBattle, IFormation, IAirbattle, ISupport, IAirBaseAttack, Serializable {
 
-    private static final long serialVersionUID = -6199870579231576550L;
+    private static final long serialVersionUID = 9151084407917872026L;
 
     /** api_air_base_injection */
     private BattleTypes.AirBaseAttack airBaseInjection;
@@ -88,6 +88,15 @@ public class SortieAirbattle implements ISortieBattle, IFormation, IAirbattle, I
     /** api_kouku2 */
     private BattleTypes.Kouku kouku2;
 
+    /** api_smoke_type */
+    private Integer smokeType;
+
+    /** api_balloon_cell */
+    private Integer balloonCell;
+
+    /** api_atoll_cell */
+    private Integer atollCell;
+
     /**
      * JsonObjectから{@link SortieAirbattle}を構築します
      *
@@ -121,7 +130,10 @@ public class SortieAirbattle implements ISortieBattle, IFormation, IAirbattle, I
                 .setInteger("api_support_flag", bean::setSupportFlag)
                 .set("api_support_info", bean::setSupportInfo, BattleTypes.SupportInfo::toSupportInfo)
                 .setIntegerList("api_stage_flag2", bean::setStageFlag2)
-                .set("api_kouku2", bean::setKouku2, BattleTypes.Kouku::toKouku);
+                .set("api_kouku2", bean::setKouku2, BattleTypes.Kouku::toKouku)
+                .setInteger("api_smoke_type", bean::setSmokeType)
+                .setInteger("api_balloon_cell", bean::setBalloonCell)
+                .setInteger("api_atoll_cell", bean::setAtollCell);
         return bean;
     }
 }

--- a/src/main/java/logbook/bean/SortieBattle.java
+++ b/src/main/java/logbook/bean/SortieBattle.java
@@ -22,7 +22,7 @@ import lombok.Data;
 public class SortieBattle
         implements ISortieBattle, ISortieHougeki, IFormation, IKouku, ISupport, IAirBaseAttack, Serializable {
 
-    private static final long serialVersionUID = 3020709530421134903L;
+    private static final long serialVersionUID = -8436324168764246809L;
 
     /** api_air_base_injection */
     private BattleTypes.AirBaseAttack airBaseInjection;
@@ -111,6 +111,15 @@ public class SortieBattle
     /** api_hougeki3 */
     private BattleTypes.Hougeki hougeki3;
 
+    /** api_smoke_type */
+    private Integer smokeType;
+
+    /** api_balloon_cell */
+    private Integer balloonCell;
+
+    /** api_atoll_cell */
+    private Integer atollCell;
+
     /**
      * JsonObjectから{@link SortieBattle}を構築します
      *
@@ -151,7 +160,10 @@ public class SortieBattle
                 .set("api_hougeki1", bean::setHougeki1, BattleTypes.Hougeki::toHougeki)
                 .set("api_raigeki", bean::setRaigeki, BattleTypes.Raigeki::toRaigeki)
                 .set("api_hougeki2", bean::setHougeki2, BattleTypes.Hougeki::toHougeki)
-                .set("api_hougeki3", bean::setHougeki3, BattleTypes.Hougeki::toHougeki);
+                .set("api_hougeki3", bean::setHougeki3, BattleTypes.Hougeki::toHougeki)
+                .setInteger("api_smoke_type", bean::setSmokeType)
+                .setInteger("api_balloon_cell", bean::setBalloonCell)
+                .setInteger("api_atoll_cell", bean::setAtollCell);
         return bean;
     }
 }

--- a/src/main/java/logbook/bean/SortieBattle.java
+++ b/src/main/java/logbook/bean/SortieBattle.java
@@ -88,7 +88,7 @@ public class SortieBattle
     private Boolean openingFlag;
 
     /** api_opening_atack */
-    private BattleTypes.Raigeki openingAtack;
+    private BattleTypes.OpeningAtack openingAtack;
 
     /** api_opening_taisen_flag */
     private Boolean openingTaisenFlag;
@@ -144,7 +144,7 @@ public class SortieBattle
                 .setInteger("api_support_flag", bean::setSupportFlag)
                 .set("api_support_info", bean::setSupportInfo, BattleTypes.SupportInfo::toSupportInfo)
                 .setBoolean("api_opening_flag", bean::setOpeningFlag)
-                .set("api_opening_atack", bean::setOpeningAtack, BattleTypes.Raigeki::toRaigeki)
+                .set("api_opening_atack", bean::setOpeningAtack, BattleTypes.OpeningAtack::toOpeningAtack)
                 .setBoolean("api_opening_taisen_flag", bean::setOpeningTaisenFlag)
                 .set("api_opening_taisen", bean::setOpeningTaisen, BattleTypes.Hougeki::toHougeki)
                 .setIntegerList("api_hourai_flag", bean::setHouraiFlag)

--- a/src/main/java/logbook/bean/SortieLdAirbattle.java
+++ b/src/main/java/logbook/bean/SortieLdAirbattle.java
@@ -21,7 +21,7 @@ import lombok.Data;
 public class SortieLdAirbattle
         implements ISortieBattle, IFormation, IKouku, IAirBaseAttack, ILdAirbattle, Serializable {
 
-    private static final long serialVersionUID = -1090849552625550232L;
+    private static final long serialVersionUID = 2405183386671331819L;
 
     /** api_air_base_injection */
     private BattleTypes.AirBaseAttack airBaseInjection;
@@ -77,6 +77,15 @@ public class SortieLdAirbattle
     /** api_kouku */
     private BattleTypes.Kouku kouku;
 
+    /** api_smoke_type */
+    private Integer smokeType;
+
+    /** api_balloon_cell */
+    private Integer balloonCell;
+
+    /** api_atoll_cell */
+    private Integer atollCell;
+
     /**
      * JsonObjectから{@link SortieLdAirbattle}を構築します
      *
@@ -106,7 +115,10 @@ public class SortieLdAirbattle
                 .setIntegerList("api_formation", bean::setFormation)
                 .setIntegerList("api_stage_flag", bean::setStageFlag)
                 .set("api_injection_kouku", bean::setInjectionKouku, BattleTypes.Kouku::toKouku)
-                .set("api_kouku", bean::setKouku, BattleTypes.Kouku::toKouku);
+                .set("api_kouku", bean::setKouku, BattleTypes.Kouku::toKouku)
+                .setInteger("api_smoke_type", bean::setSmokeType)
+                .setInteger("api_balloon_cell", bean::setBalloonCell)
+                .setInteger("api_atoll_cell", bean::setAtollCell);
         return bean;
     }
 }

--- a/src/main/java/logbook/bean/SortieLdShooting.java
+++ b/src/main/java/logbook/bean/SortieLdShooting.java
@@ -24,7 +24,7 @@ public class SortieLdShooting
         implements ISortieBattle, ISortieHougeki, IFormation, IKouku, ISupport, IAirBaseAttack, ILdShooting,
         Serializable {
 
-    private static final long serialVersionUID = 3020709530421134903L;
+    private static final long serialVersionUID = 1027540931483394988L;
 
     /** api_air_base_injection */
     private BattleTypes.AirBaseAttack airBaseInjection;
@@ -113,6 +113,15 @@ public class SortieLdShooting
     /** api_hougeki3 */
     private BattleTypes.Hougeki hougeki3;
 
+    /** api_smoke_type */
+    private Integer smokeType;
+
+    /** api_balloon_cell */
+    private Integer balloonCell;
+
+    /** api_atoll_cell */
+    private Integer atollCell;
+
     /**
      * JsonObjectから{@link SortieLdShooting}を構築します
      *
@@ -153,7 +162,10 @@ public class SortieLdShooting
                 .set("api_hougeki1", bean::setHougeki1, BattleTypes.Hougeki::toHougeki)
                 .set("api_raigeki", bean::setRaigeki, BattleTypes.Raigeki::toRaigeki)
                 .set("api_hougeki2", bean::setHougeki2, BattleTypes.Hougeki::toHougeki)
-                .set("api_hougeki3", bean::setHougeki3, BattleTypes.Hougeki::toHougeki);
+                .set("api_hougeki3", bean::setHougeki3, BattleTypes.Hougeki::toHougeki)
+                .setInteger("api_smoke_type", bean::setSmokeType)
+                .setInteger("api_balloon_cell", bean::setBalloonCell)
+                .setInteger("api_atoll_cell", bean::setAtollCell);
         return bean;
     }
 }

--- a/src/main/java/logbook/bean/SortieLdShooting.java
+++ b/src/main/java/logbook/bean/SortieLdShooting.java
@@ -90,7 +90,7 @@ public class SortieLdShooting
     private Boolean openingFlag;
 
     /** api_opening_atack */
-    private BattleTypes.Raigeki openingAtack;
+    private BattleTypes.OpeningAtack openingAtack;
 
     /** api_opening_taisen_flag */
     private Boolean openingTaisenFlag;
@@ -146,7 +146,7 @@ public class SortieLdShooting
                 .setInteger("api_support_flag", bean::setSupportFlag)
                 .set("api_support_info", bean::setSupportInfo, BattleTypes.SupportInfo::toSupportInfo)
                 .setBoolean("api_opening_flag", bean::setOpeningFlag)
-                .set("api_opening_atack", bean::setOpeningAtack, BattleTypes.Raigeki::toRaigeki)
+                .set("api_opening_atack", bean::setOpeningAtack, BattleTypes.OpeningAtack::toOpeningAtack)
                 .setBoolean("api_opening_taisen_flag", bean::setOpeningTaisenFlag)
                 .set("api_opening_taisen", bean::setOpeningTaisen, BattleTypes.Hougeki::toHougeki)
                 .setIntegerList("api_hourai_flag", bean::setHouraiFlag)

--- a/src/main/java/logbook/internal/PhaseState.java
+++ b/src/main/java/logbook/internal/PhaseState.java
@@ -856,6 +856,9 @@ public class PhaseState {
     private void addDetailRaigeki0(List<? extends Chara> attackerFleet, List<? extends Chara> attackerFleetCombined,
             List<? extends Chara> defenderFleet, List<? extends Chara> defenderFleetCombined,
             List<Integer> index, List<Double> ydam, List<Integer> critical) {
+        if (index == null || ydam == null || critical == null) {
+            return;
+        }
 
         if (defenderFleet != null)
             defenderFleet = defenderFleet.stream()

--- a/src/main/java/logbook/internal/PhaseState.java
+++ b/src/main/java/logbook/internal/PhaseState.java
@@ -13,8 +13,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import logbook.bean.AppCondition;
-import logbook.bean.BattleLog;
+import logbook.bean.*;
 import logbook.bean.BattleTypes.AirBaseAttack;
 import logbook.bean.BattleTypes.AtType;
 import logbook.bean.BattleTypes.CombinedType;
@@ -42,13 +41,6 @@ import logbook.bean.BattleTypes.Stage3;
 import logbook.bean.BattleTypes.SupportAiratack;
 import logbook.bean.BattleTypes.SupportHourai;
 import logbook.bean.BattleTypes.SupportInfo;
-import logbook.bean.Chara;
-import logbook.bean.Enemy;
-import logbook.bean.Friend;
-import logbook.bean.Ship;
-import logbook.bean.SlotItem;
-import logbook.bean.SlotItemCollection;
-import logbook.bean.SlotitemMst;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.Getter;
@@ -252,8 +244,8 @@ public class PhaseState {
     public void applySortieHougeki(ISortieHougeki battle) {
         // 先制対潜攻撃
         this.applyHougeki(battle.getOpeningTaisen());
-        // 開幕雷撃
-        this.applyRaigeki(battle.getOpeningAtack());
+        // 開幕攻撃
+        this.applyOpeningAtack(battle.getOpeningAtack());
         if (!this.combined && battle.isICombinedEcBattle()) {
             // 1巡目
             this.applyHougeki(battle.getHougeki1());
@@ -518,6 +510,22 @@ public class PhaseState {
                 this.applyEnemyDamage(hou.getDamage());
             }
         }
+    }
+
+    /**
+     * 開幕攻撃フェイズを適用します
+     *
+     * @param openingAtack 開幕攻撃フェイズ
+     */
+    private void applyOpeningAtack(BattleTypes.OpeningAtack openingAtack) {
+        if (openingAtack == null) {
+            return;
+        }
+        this.addDetailOpeningAtack(openingAtack);
+        // 新API
+        this.applyFriendDamage(openingAtack.getFdam());
+        // 敵
+        this.applyEnemyDamage(openingAtack.getEdam());
     }
 
     /**
@@ -828,6 +836,67 @@ public class PhaseState {
     }
 
     /**
+     * ダメージ詳細(開幕攻撃)
+     *
+     * @param openingAtack
+     */
+    private void addDetailOpeningAtack(BattleTypes.OpeningAtack openingAtack) {
+        // 敵→味方
+        this.addDetailOpeningAtack0(this.afterEnemy, this.afterEnemyCombined, this.afterFriend,
+                this.afterFriendCombined,
+                openingAtack.getEraiListItems(), openingAtack.getEydamListItems(), openingAtack.getEclListItems());
+        // 味方→敵
+        this.addDetailOpeningAtack0(this.afterFriend, this.afterFriendCombined, this.afterEnemy, this.afterEnemyCombined,
+                openingAtack.getFraiListItems(), openingAtack.getFydamListItems(), openingAtack.getFclListItems());
+    }
+
+    /**
+     * ダメージ詳細(開幕攻撃)
+     *
+     * @param attackerFleet         攻撃側艦隊
+     * @param attackerFleetCombined 攻撃側艦隊(第2艦隊)
+     * @param defenderFleet         防御側艦隊
+     * @param defenderFleetCombined 防御側艦隊(第2艦隊)
+     * @param indexList             攻撃対象インデックス
+     * @param ydamList              与ダメージ
+     * @param criticalList          クリティカル
+     */
+    private void addDetailOpeningAtack0(List<? extends Chara> attackerFleet, List<? extends Chara> attackerFleetCombined,
+            List<? extends Chara> defenderFleet, List<? extends Chara> defenderFleetCombined,
+            List<List<Integer>> indexList, List<List<Double>> ydamList, List<List<Integer>> critical) {
+        if (defenderFleet != null)
+            defenderFleet = defenderFleet.stream()
+                    .map(c -> c != null ? c.clone() : null)
+                    .collect(Collectors.toList());
+        if (defenderFleetCombined != null)
+            defenderFleetCombined = defenderFleetCombined.stream()
+                    .map(c -> c != null ? c.clone() : null)
+                    .collect(Collectors.toList());
+        for (int i = 0; i < indexList.size(); i++) {
+            List<Integer> index = indexList.get(i);
+            if (index == null || index.isEmpty()) {
+                continue;
+            }
+            Chara attacker = Math.max(attackerFleet.size(), 6) > i
+                    ? attackerFleet.get(i)
+                    : attackerFleetCombined.get(i - 6);
+            for (int j = 0; j < index.size(); j++) {
+                Chara defender = Math.max(defenderFleet.size(), 6) > index.get(j)
+                        ? defenderFleet.get(index.get(j))
+                        : defenderFleetCombined.get(index.get(j) - 6);
+
+                int damage = (int) ydamList.get(i).get(j).doubleValue();
+
+                defender.setNowhp(defender.getNowhp() - damage);
+
+                this.addDetail(attacker, defender, damage, Collections.singletonList(damage),
+                        Collections.singletonList(critical.get(i).get(j)),
+                        SortieAtTypeRaigeki.通常雷撃);
+            }
+        }
+    }
+
+    /**
      * ダメージ詳細(雷撃)
      *
      * @param raigeki
@@ -856,10 +925,6 @@ public class PhaseState {
     private void addDetailRaigeki0(List<? extends Chara> attackerFleet, List<? extends Chara> attackerFleetCombined,
             List<? extends Chara> defenderFleet, List<? extends Chara> defenderFleetCombined,
             List<Integer> index, List<Double> ydam, List<Integer> critical) {
-        if (index == null || ydam == null || critical == null) {
-            return;
-        }
-
         if (defenderFleet != null)
             defenderFleet = defenderFleet.stream()
                     .map(c -> c != null ? c.clone() : null)

--- a/src/main/java/logbook/internal/SeaAreaBanner.java
+++ b/src/main/java/logbook/internal/SeaAreaBanner.java
@@ -21,7 +21,7 @@ class SeaAreaBanner {
         String bannerFormat;
         int imageNumber;
 
-        // 2024年春イベント暫定版
+        // 2024年早春イベント暫定版
         switch (area) {
             case 1:
             case 2:
@@ -33,21 +33,13 @@ class SeaAreaBanner {
                 bannerFormat = JOIN_BANNER;
                 imageNumber = area + 34;
                 break;
-                /*
             case 8:
             case 9:
-                bannerFormat = JOIN_BANNER_2;
-                imageNumber = area + 10;
-                break;
             case 10:
-                bannerFormat = JOIN_BANNER_2;
-                imageNumber = 16;
-                break;
             case 11:
-                bannerFormat = JOIN_BANNER_3;
-                imageNumber = 12;
+                bannerFormat = JOIN_BANNER_2;
+                imageNumber = area + 4;
                 break;
-                 */
             default:
                 return null;
         }

--- a/src/main/java/logbook/internal/SeaAreaBanner.java
+++ b/src/main/java/logbook/internal/SeaAreaBanner.java
@@ -21,7 +21,7 @@ class SeaAreaBanner {
         String bannerFormat;
         int imageNumber;
 
-        // 2023年夏イベント最終版
+        // 2024年春イベント暫定版
         switch (area) {
             case 1:
             case 2:
@@ -29,10 +29,11 @@ class SeaAreaBanner {
             case 4:
             case 5:
             case 6:
-                bannerFormat = JOIN_BANNER;
-                imageNumber = area + 32;
-                break;
             case 7:
+                bannerFormat = JOIN_BANNER;
+                imageNumber = area + 34;
+                break;
+                /*
             case 8:
             case 9:
                 bannerFormat = JOIN_BANNER_2;
@@ -46,6 +47,7 @@ class SeaAreaBanner {
                 bannerFormat = JOIN_BANNER_3;
                 imageNumber = 12;
                 break;
+                 */
             default:
                 return null;
         }

--- a/src/main/java/logbook/internal/gui/ConfigController.java
+++ b/src/main/java/logbook/internal/gui/ConfigController.java
@@ -314,6 +314,9 @@ public class ConfigController extends WindowController {
     @FXML
     private Button storeApiStart2DirRef;
 
+    @FXML
+    private CheckBox usePassiveMode;
+
     /** FFmpeg 実行ファイル */
     @FXML
     private TextField ffmpegPath;
@@ -509,6 +512,7 @@ public class ConfigController extends WindowController {
         this.storeInternal.setSelected(conf.isStoreApiStart2());
         this.storeApiStart2.setSelected(conf.isStoreApiStart2());
         this.storeApiStart2Dir.setText(conf.getStoreApiStart2Dir());
+        this.usePassiveMode.setSelected(conf.isUsePassiveMode());
         this.storeInternal.getOnAction().handle(new ActionEvent());
 
         this.pluginName.setCellValueFactory(new PropertyValueFactory<>("name"));
@@ -627,7 +631,8 @@ public class ConfigController extends WindowController {
         conf.setProxyPort(this.toInt(this.proxyPort.getText()));
         conf.setStoreApiStart2(this.storeApiStart2.isSelected());
         conf.setStoreApiStart2Dir(this.storeApiStart2Dir.getText());
-        
+        conf.setUsePassiveMode(this.usePassiveMode.isSelected());
+
         conf.setFfmpegPath(this.ffmpegPath.getText());
         conf.setFfmpegArgs(this.ffmpegArgs.getText());
         conf.setFfmpegExt(this.ffmpegExt.getText());

--- a/src/main/java/logbook/internal/gui/ConfigController.java
+++ b/src/main/java/logbook/internal/gui/ConfigController.java
@@ -282,10 +282,6 @@ public class ConfigController extends WindowController {
     @FXML
     private CheckBox visiblePoseImageOnFleetTab;
 
-    /** 通信エラーの抑止 */
-    @FXML
-    private CheckBox connectionClose;
-
     /** ポート番号 */
     @FXML
     private TextField listenPort;
@@ -500,7 +496,6 @@ public class ConfigController extends WindowController {
         this.hideShipImageFromShipTablePane.setSelected(conf.isHideShipImageFromShipTablePane());
         this.hideItemImageFromShipTablePane.setSelected(conf.isHideItemImageFromShipTablePane());
         this.visiblePoseImageOnFleetTab.setSelected(conf.isVisiblePoseImageOnFleetTab());
-        this.connectionClose.setSelected(conf.isConnectionClose());
         this.listenPort.setText(Integer.toString(conf.getListenPort()));
         this.allowOnlyFromLocalhost.setSelected(conf.isAllowOnlyFromLocalhost());
         this.useProxy.setSelected(conf.isUseProxy());
@@ -625,7 +620,6 @@ public class ConfigController extends WindowController {
         conf.setHideItemImageFromShipTablePane(this.hideItemImageFromShipTablePane.isSelected());
         conf.setVisiblePoseImageOnFleetTab(this.visiblePoseImageOnFleetTab.isSelected());
         
-        conf.setConnectionClose(this.connectionClose.isSelected());
         conf.setListenPort(this.toInt(this.listenPort.getText()));
         conf.setAllowOnlyFromLocalhost(this.allowOnlyFromLocalhost.isSelected());
         conf.setUseProxy(this.useProxy.isSelected());

--- a/src/main/java/logbook/internal/proxy/ProxyServerImpl.java
+++ b/src/main/java/logbook/internal/proxy/ProxyServerImpl.java
@@ -56,11 +56,13 @@ public final class ProxyServerImpl implements ProxyServerSpi {
             holder.setInitParameter("timeout", "600000");
             context.addServlet(holder, "/*");
 
-            // パッシブモードのハンドラをセット
-            ServletHolder passive = new ServletHolder(new PassiveModeServlet());
-            passive.setInitParameter("maxThreads", "128");
-            passive.setInitParameter("timeout", "300000");
-            context.addServlet(passive, PassiveModeServlet.PATH_SPEC);
+            if (AppConfig.get().isUsePassiveMode()) {
+                // パッシブモードのハンドラをセット
+                ServletHolder passive = new ServletHolder(new PassiveModeServlet());
+                passive.setInitParameter("maxThreads", "128");
+                passive.setInitParameter("timeout", "300000");
+                context.addServlet(passive, PassiveModeServlet.PATH_SPEC);
+            }
 
             try {
                 try {

--- a/src/main/resources/logbook/gui/config.fxml
+++ b/src/main/resources/logbook/gui/config.fxml
@@ -292,19 +292,18 @@
                               <RowConstraints prefHeight="30.0" vgrow="SOMETIMES" />
                            </rowConstraints>
                            <children>
-                              <CheckBox fx:id="connectionClose" mnemonicParsing="false" text="通信エラーの抑止(Connection: closeヘッダを追加)*" GridPane.columnSpan="2147483647" />
-                              <Label text="ポート番号*" GridPane.rowIndex="1" />
-                              <TextField fx:id="listenPort" prefWidth="150.0" GridPane.columnIndex="1" GridPane.rowIndex="1" />
-                              <CheckBox fx:id="allowOnlyFromLocalhost" mnemonicParsing="false" text="ローカルループバックアドレスからの接続のみ受け入れる*" GridPane.columnSpan="2147483647" GridPane.rowIndex="2" />
-                              <CheckBox fx:id="useProxy" mnemonicParsing="false" text="接続にプロキシを使用する(他ツール連携)*" GridPane.columnSpan="2147483647" GridPane.rowIndex="3" />
-                              <Label text="プロキシホスト*" GridPane.rowIndex="4" />
-                              <TextField fx:id="proxyHost" prefWidth="150.0" GridPane.columnIndex="1" GridPane.rowIndex="4" />
-                              <Label text="プロキシポート番号*" GridPane.rowIndex="5" />
-                              <TextField fx:id="proxyPort" prefWidth="150.0" GridPane.columnIndex="1" GridPane.rowIndex="5" />
-                              <CheckBox fx:id="storeInternal" mnemonicParsing="false" onAction="#storeInternal" text="内部データを保存する(試験的)" GridPane.columnSpan="2147483647" GridPane.rowIndex="6" />
-                              <CheckBox fx:id="storeApiStart2" mnemonicParsing="false" onAction="#storeApiStart2" text="api_start2" GridPane.rowIndex="7" />
-                              <TextField fx:id="storeApiStart2Dir" prefWidth="200.0" GridPane.columnIndex="1" GridPane.rowIndex="7" />
-                              <Button fx:id="storeApiStart2DirRef" mnemonicParsing="false" onAction="#selectApiStart2Dir" text="参照..." GridPane.columnIndex="2" GridPane.rowIndex="7" />
+                              <Label text="ポート番号*" GridPane.rowIndex="0" />
+                              <TextField fx:id="listenPort" prefWidth="150.0" GridPane.columnIndex="1" GridPane.rowIndex="0" />
+                              <CheckBox fx:id="allowOnlyFromLocalhost" mnemonicParsing="false" text="ローカルループバックアドレスからの接続のみ受け入れる*" GridPane.columnSpan="2147483647" GridPane.rowIndex="1" />
+                              <CheckBox fx:id="useProxy" mnemonicParsing="false" text="接続にプロキシを使用する(他ツール連携)*" GridPane.columnSpan="2147483647" GridPane.rowIndex="2" />
+                              <Label text="プロキシホスト*" GridPane.rowIndex="3" />
+                              <TextField fx:id="proxyHost" prefWidth="150.0" GridPane.columnIndex="1" GridPane.rowIndex="3" />
+                              <Label text="プロキシポート番号*" GridPane.rowIndex="4" />
+                              <TextField fx:id="proxyPort" prefWidth="150.0" GridPane.columnIndex="1" GridPane.rowIndex="4" />
+                              <CheckBox fx:id="storeInternal" mnemonicParsing="false" onAction="#storeInternal" text="内部データを保存する(試験的)" GridPane.columnSpan="2147483647" GridPane.rowIndex="5" />
+                              <CheckBox fx:id="storeApiStart2" mnemonicParsing="false" onAction="#storeApiStart2" text="api_start2" GridPane.rowIndex="6" />
+                              <TextField fx:id="storeApiStart2Dir" prefWidth="200.0" GridPane.columnIndex="1" GridPane.rowIndex="6" />
+                              <Button fx:id="storeApiStart2DirRef" mnemonicParsing="false" onAction="#selectApiStart2Dir" text="参照..." GridPane.columnIndex="2" GridPane.rowIndex="6" />
                            </children>
                         </GridPane>
                      </children>

--- a/src/main/resources/logbook/gui/config.fxml
+++ b/src/main/resources/logbook/gui/config.fxml
@@ -304,6 +304,7 @@
                               <CheckBox fx:id="storeApiStart2" mnemonicParsing="false" onAction="#storeApiStart2" text="api_start2" GridPane.rowIndex="6" />
                               <TextField fx:id="storeApiStart2Dir" prefWidth="200.0" GridPane.columnIndex="1" GridPane.rowIndex="6" />
                               <Button fx:id="storeApiStart2DirRef" mnemonicParsing="false" onAction="#selectApiStart2Dir" text="参照..." GridPane.columnIndex="2" GridPane.rowIndex="6" />
+                              <CheckBox fx:id="usePassiveMode" mnemonicParsing="false" text="パッシブモードを有効にする(試験的)*" GridPane.columnSpan="2147483647" GridPane.rowIndex="7" />
                            </children>
                         </GridPane>
                      </children>


### PR DESCRIPTION
## 変更内容

### 2024早春イベ暫定対応

- api_opening_atack の仕様変更に対応。まだ不備はあるかも。
- 海域札の表示に対応。まだ出撃していないのでズレてるかも。

### 設定＞通信

- 使われていなかった `通信エラーの抑止(Connection: closeヘッダを追加)*` を削除
- `パッシブモードを有効にする(試験的)*` を追加
  - プロキシでなくHTTP POSTでAPIレスポンス情報を受け取るモードです。外部のプロキシと組み合わせて航海日誌をGUIとして利用することを想定した機能です。(あえて多段プロキシでなく)
    - パス: `/pasv/<オリジナルのパス (query stringも含む)>`
    - ヘッダ:
      - レスポンスヘッダそのままに加えて、以下のヘッダを追加。
      - `X-Pasv-Request-Method`: オリジナルのHTTPリクエストメソッド
      - `X-Pasv-Request-Content-Type`: オリジナルのHTTPリクエストのContent-Typeヘッダ (optional)
      - `X-Pasv-Request-Body`: オリジナルのHTTPリクエストボディをBase64エンコードしたもの (optional)
        - `application/x-www-form-urlencoded` なパラメータを受け取ることを想定したヘッダです。
    - ボディ
      - レスポンスボディそのまま。