### PR TITLE
v24.3.3

### DIFF
--- a/pom-java17.xml
+++ b/pom-java17.xml
@@ -4,7 +4,7 @@
     <name>logbook-kai</name>
     <artifactId>logbook-kai-java17</artifactId>
     <groupId>logbook</groupId>
-    <version>24.3.2</version>
+    <version>24.3.3</version>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <name>logbook-kai</name>
     <artifactId>logbook-kai</artifactId>
     <groupId>logbook</groupId>
-    <version>24.3.2</version>
+    <version>24.3.3</version>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>1.8</java.version>

--- a/src/main/java/logbook/bean/BattleTypes.java
+++ b/src/main/java/logbook/bean/BattleTypes.java
@@ -413,7 +413,7 @@ public class BattleTypes {
          * api_opening_atackを取得します。
          * @return api_opening_atack
          */
-        BattleTypes.OpeningAtack getOpeningAtack();
+        OpeningAtackCompat getOpeningAtack();
 
         /**
          * api_opening_taisen_flagを取得します。
@@ -1133,12 +1133,117 @@ public class BattleTypes {
     }
 
     /**
+     * 雷撃戦フェイズ
+     */
+    public interface IRaigeki {
+        /**
+         * api_fdamを取得します。
+         * @return api_fdam
+         */
+        List<Double> getFdam();
+
+        /**
+         * api_edamを取得します。
+         * @return api_edam
+         */
+        List<Double> getEdam();
+
+        /**
+         * api_fraiを取得します。
+         * @return api_frai
+         */
+        List<Integer> getFrai();
+
+        /**
+         * api_eraiを取得します。
+         * @return api_erai
+         */
+        List<Integer> getErai();
+
+        /**
+         * api_fydamを取得します。
+         * @return api_fydam
+         */
+        List<Double> getFydam();
+
+        /**
+         * api_eydamを取得します。
+         * @return api_eydam
+         */
+        List<Double> getEydam();
+
+        /**
+         * api_fclを取得します。
+         * @return api_fcl
+         */
+        List<Integer> getFcl();
+
+        /**
+         * api_eclを取得します。
+         * @return api_ecl
+         */
+        List<Integer> getEcl();
+    }
+
+    /**
+     * 開幕戦フェイズ (2024-03-01のアップデート以降の仕様)
+     */
+    public interface IOpeningAtack {
+        /**
+         * api_frai_list_itemsを取得します。
+         * @return api_frai_list_items
+         */
+        List<List<Integer>> getFraiListItems();
+
+        /**
+         * api_fcl_list_itemsを取得します。
+         * @return api_fcl_list_items
+         */
+        List<List<Integer>> getFclListItems();
+
+        /**
+         * api_fdamを取得します。
+         *
+         * @return api_fdam
+         */
+        List<Double> getFdam();
+
+        /**
+         * api_fydam_list_itemsを取得します。
+         * @return api_fydam_list_items
+         */
+        List<List<Double>> getFydamListItems();
+
+        /**
+         * api_erai_list_itemsを取得します。
+         * @return api_erai_list_items
+         */
+        List<List<Integer>> getEraiListItems();
+
+        /**
+         * api_ecl_list_itemsを取得します。
+         * @return api_ecl_list_items
+         */
+        List<List<Integer>> getEclListItems();
+
+        /**
+         * api_edamを取得します。
+         * @return api_edam
+         */
+        List<Double> getEdam();
+
+        /**
+         * api_eydam_list_itemsを取得します。
+         * @return api_eydam_list_items
+         */
+        List<List<Double>> getEydamListItems();
+    }
+
+    /**
      * 開幕 (新旧仕様の互換用ラッパー）
-     *
-     * "atack" は "attack" のtypoなのだが、API仕様としては "api_opening_atack" なのでそのまま採用
      */
     @Data
-    public static class OpeningAtack implements Serializable {
+    public static class OpeningAtackCompat implements IRaigeki, IOpeningAtack, Serializable {
         private static final long serialVersionUID = 6763111484816184379L;
 
         // 2024-03-01のアップデート前後で共通の仕様
@@ -1156,7 +1261,6 @@ public class BattleTypes {
 
         /** api_erai */
         private List<Integer> erai = null;
-
 
         /** api_fydam */
         private List<Double> fydam = null;
@@ -1191,82 +1295,50 @@ public class BattleTypes {
         private List<List<Double>> eydamListItems = null;
 
         // デシリアライズ用にデフォルトコンストラクタが必要
-        public OpeningAtack() {
+        public OpeningAtackCompat() {
         }
 
-        private OpeningAtack(Raigeki raigeki) {
-            this.frai = raigeki.getFrai();
-            this.erai = raigeki.getErai();
-            this.fdam = raigeki.getFdam();
-            this.edam = raigeki.getEdam();
-            this.fydam = raigeki.getFydam();
-            this.eydam = raigeki.getEydam();
-            this.fcl = raigeki.getFcl();
-            this.ecl = raigeki.getEcl();
+        private OpeningAtackCompat(IRaigeki bean) {
+            this.frai = bean.getFrai();
+            this.erai = bean.getErai();
+            this.fdam = bean.getFdam();
+            this.edam = bean.getEdam();
+            this.fydam = bean.getFydam();
+            this.eydam = bean.getEydam();
+            this.fcl = bean.getFcl();
+            this.ecl = bean.getEcl();
         }
 
-        private OpeningAtack(OpeningAtackV2 openingAtackV2) {
-            this.fraiListItems = openingAtackV2.getFraiListItems();
-            this.fclListItems = openingAtackV2.getFclListItems();
-            this.fdam = openingAtackV2.getFdam();
-            this.fydamListItems = openingAtackV2.getFydamListItems();
-            this.eraiListItems = openingAtackV2.getEraiListItems();
-            this.eclListItems = openingAtackV2.getEclListItems();
-            this.edam = openingAtackV2.getEdam();
-            this.eydamListItems = openingAtackV2.getEydamListItems();
-        }
-
-        public Raigeki asRaigeki() {
-            if (!this.isRaigeki()) {
-                return null;
-            }
-            Raigeki bean = new Raigeki();
-            bean.setFrai(this.frai);
-            bean.setErai(this.erai);
-            bean.setFdam(this.fdam);
-            bean.setEdam(this.edam);
-            bean.setFydam(this.fydam);
-            bean.setEydam(this.eydam);
-            bean.setFcl(this.fcl);
-            bean.setEcl(this.ecl);
-            return bean;
-        }
-
-        public OpeningAtackV2 asOpeningAtackV2() {
-            if (!this.isOpeningAtackV2()) {
-                return null;
-            }
-            OpeningAtackV2 bean = new OpeningAtackV2();
-            bean.setFraiListItems(this.fraiListItems);
-            bean.setFclListItems(this.fclListItems);
-            bean.setFdam(this.fdam);
-            bean.setFydamListItems(this.fydamListItems);
-            bean.setEraiListItems(this.eraiListItems);
-            bean.setEclListItems(this.eclListItems);
-            bean.setEdam(this.edam);
-            bean.setEydamListItems(this.eydamListItems);
-            return bean;
+        private OpeningAtackCompat(IOpeningAtack bean) {
+            this.fraiListItems = bean.getFraiListItems();
+            this.fclListItems = bean.getFclListItems();
+            this.fdam = bean.getFdam();
+            this.fydamListItems = bean.getFydamListItems();
+            this.eraiListItems = bean.getEraiListItems();
+            this.eclListItems = bean.getEclListItems();
+            this.edam = bean.getEdam();
+            this.eydamListItems = bean.getEydamListItems();
         }
 
         public boolean isRaigeki() {
             return this.frai != null;
         }
 
-        public boolean isOpeningAtackV2() {
+        public boolean isOpeningAtack() {
             return this.fraiListItems != null;
         }
 
         /**
-         * JsonObjectから{@link OpeningAtack}を構築します
+         * JsonObjectから{@link OpeningAtackCompat}を構築します
          *
          * @param json JsonObject
-         * @return {@link OpeningAtack}
+         * @return {@link OpeningAtackCompat}
          */
-        public static OpeningAtack toOpeningAtack(JsonObject json) {
+        public static OpeningAtackCompat toOpeningAtackCompat(JsonObject json) {
             if (json.containsKey("api_frai_list_items") && json.get("api_frai_list_items") instanceof JsonArray) {
-                return new OpeningAtack(OpeningAtackV2.toOpeningAtackV2(json));
+                return new OpeningAtackCompat(OpeningAtack.toOpeningAtack(json));
             } else {
-                return new OpeningAtack(Raigeki.toRaigeki(json));
+                return new OpeningAtackCompat(Raigeki.toRaigeki(json));
             }
         }
     }
@@ -1275,7 +1347,7 @@ public class BattleTypes {
      * 開幕 (2024-03-01のアップデート以降の仕様)
      */
     @Data
-    public static class OpeningAtackV2 implements Serializable {
+    public static class OpeningAtack implements IOpeningAtack, Serializable {
         private static final long serialVersionUID = 5826255800868507590L;
 
         /** api_frai_list_items */
@@ -1303,13 +1375,13 @@ public class BattleTypes {
         private List<List<Double>> eydamListItems;
 
         /**
-         * JsonObjectから{@link OpeningAtackV2}を構築します
+         * JsonObjectから{@link OpeningAtack}を構築します
          *
          * @param json JsonObject
-         * @return {@link OpeningAtackV2}
+         * @return {@link OpeningAtack}
          */
-        public static OpeningAtackV2 toOpeningAtackV2(JsonObject json) {
-            OpeningAtackV2 bean = new OpeningAtackV2();
+        public static OpeningAtack toOpeningAtack(JsonObject json) {
+            OpeningAtack bean = new OpeningAtack();
             JsonHelper.bind(json)
                     .set("api_frai_list_items", bean::setFraiListItems, JsonHelper.toList(JsonHelper::checkedToIntegerList))
                     .set("api_fcl_list_items", bean::setFclListItems, JsonHelper.toList(JsonHelper::checkedToIntegerList))
@@ -1327,7 +1399,7 @@ public class BattleTypes {
      * 雷撃
      */
     @Data
-    public static class Raigeki implements Serializable {
+    public static class Raigeki implements IRaigeki, Serializable {
 
         private static final long serialVersionUID = 4769524848250854584L;
 

--- a/src/main/java/logbook/bean/CombinedBattleBattle.java
+++ b/src/main/java/logbook/bean/CombinedBattleBattle.java
@@ -98,7 +98,7 @@ public class CombinedBattleBattle implements ICombinedBattle, ISortieBattle, ISo
     private Boolean openingFlag;
 
     /** api_opening_atack */
-    private BattleTypes.OpeningAtack openingAtack;
+    private BattleTypes.OpeningAtackCompat openingAtack;
 
     /** api_opening_taisen_flag */
     private Boolean openingTaisenFlag;
@@ -166,7 +166,7 @@ public class CombinedBattleBattle implements ICombinedBattle, ISortieBattle, ISo
                 .setInteger("api_support_flag", bean::setSupportFlag)
                 .set("api_support_info", bean::setSupportInfo, BattleTypes.SupportInfo::toSupportInfo)
                 .setBoolean("api_opening_flag", bean::setOpeningFlag)
-                .set("api_opening_atack", bean::setOpeningAtack, BattleTypes.OpeningAtack::toOpeningAtack)
+                .set("api_opening_atack", bean::setOpeningAtack, BattleTypes.OpeningAtackCompat::toOpeningAtackCompat)
                 .setBoolean("api_opening_taisen_flag", bean::setOpeningTaisenFlag)
                 .set("api_opening_taisen", bean::setOpeningTaisen, BattleTypes.Hougeki::toHougeki)
                 .setIntegerList("api_hourai_flag", bean::setHouraiFlag)

--- a/src/main/java/logbook/bean/CombinedBattleBattleWater.java
+++ b/src/main/java/logbook/bean/CombinedBattleBattleWater.java
@@ -98,7 +98,7 @@ public class CombinedBattleBattleWater implements ICombinedBattle, ISortieBattle
     private Boolean openingFlag;
 
     /** api_opening_atack */
-    private BattleTypes.OpeningAtack openingAtack;
+    private BattleTypes.OpeningAtackCompat openingAtack;
 
     /** api_opening_taisen_flag */
     private Boolean openingTaisenFlag;
@@ -166,7 +166,7 @@ public class CombinedBattleBattleWater implements ICombinedBattle, ISortieBattle
                 .setInteger("api_support_flag", bean::setSupportFlag)
                 .set("api_support_info", bean::setSupportInfo, BattleTypes.SupportInfo::toSupportInfo)
                 .setBoolean("api_opening_flag", bean::setOpeningFlag)
-                .set("api_opening_atack", bean::setOpeningAtack, BattleTypes.OpeningAtack::toOpeningAtack)
+                .set("api_opening_atack", bean::setOpeningAtack, BattleTypes.OpeningAtackCompat::toOpeningAtackCompat)
                 .setBoolean("api_opening_taisen_flag", bean::setOpeningTaisenFlag)
                 .set("api_opening_taisen", bean::setOpeningTaisen, BattleTypes.Hougeki::toHougeki)
                 .setIntegerList("api_hourai_flag", bean::setHouraiFlag)

--- a/src/main/java/logbook/bean/CombinedBattleEachBattle.java
+++ b/src/main/java/logbook/bean/CombinedBattleEachBattle.java
@@ -117,7 +117,7 @@ public class CombinedBattleEachBattle implements ICombinedBattle, ICombinedEcBat
     private Boolean openingFlag;
 
     /** api_opening_atack */
-    private BattleTypes.OpeningAtack openingAtack;
+    private BattleTypes.OpeningAtackCompat openingAtack;
 
     /** api_opening_taisen_flag */
     private Boolean openingTaisenFlag;
@@ -191,7 +191,7 @@ public class CombinedBattleEachBattle implements ICombinedBattle, ICombinedEcBat
                 .setInteger("api_support_flag", bean::setSupportFlag)
                 .set("api_support_info", bean::setSupportInfo, BattleTypes.SupportInfo::toSupportInfo)
                 .setBoolean("api_opening_flag", bean::setOpeningFlag)
-                .set("api_opening_atack", bean::setOpeningAtack, BattleTypes.OpeningAtack::toOpeningAtack)
+                .set("api_opening_atack", bean::setOpeningAtack, BattleTypes.OpeningAtackCompat::toOpeningAtackCompat)
                 .setBoolean("api_opening_taisen_flag", bean::setOpeningTaisenFlag)
                 .set("api_opening_taisen", bean::setOpeningTaisen, BattleTypes.Hougeki::toHougeki)
                 .setIntegerList("api_hourai_flag", bean::setHouraiFlag)

--- a/src/main/java/logbook/bean/CombinedBattleEcBattle.java
+++ b/src/main/java/logbook/bean/CombinedBattleEcBattle.java
@@ -110,7 +110,7 @@ public class CombinedBattleEcBattle implements ICombinedEcBattle, ISortieBattle,
     private Boolean openingFlag;
 
     /** api_opening_atack */
-    private BattleTypes.OpeningAtack openingAtack;
+    private BattleTypes.OpeningAtackCompat openingAtack;
 
     /** api_opening_taisen_flag */
     private Boolean openingTaisenFlag;
@@ -182,7 +182,7 @@ public class CombinedBattleEcBattle implements ICombinedEcBattle, ISortieBattle,
                 .setInteger("api_support_flag", bean::setSupportFlag)
                 .set("api_support_info", bean::setSupportInfo, BattleTypes.SupportInfo::toSupportInfo)
                 .setBoolean("api_opening_flag", bean::setOpeningFlag)
-                .set("api_opening_atack", bean::setOpeningAtack, BattleTypes.OpeningAtack::toOpeningAtack)
+                .set("api_opening_atack", bean::setOpeningAtack, BattleTypes.OpeningAtackCompat::toOpeningAtackCompat)
                 .setBoolean("api_opening_taisen_flag", bean::setOpeningTaisenFlag)
                 .set("api_opening_taisen", bean::setOpeningTaisen, BattleTypes.Hougeki::toHougeki)
                 .setIntegerList("api_hourai_flag", bean::setHouraiFlag)

--- a/src/main/java/logbook/bean/CombinedBattleEcNightToDay.java
+++ b/src/main/java/logbook/bean/CombinedBattleEcNightToDay.java
@@ -142,7 +142,7 @@ public class CombinedBattleEcNightToDay implements ICombinedBattle, ICombinedEcB
     private Boolean openingFlag;
 
     /** api_opening_atack */
-    private BattleTypes.OpeningAtack openingAtack;
+    private BattleTypes.OpeningAtackCompat openingAtack;
 
     /** api_hourai_flag */
     private List<Integer> houraiFlag;
@@ -220,7 +220,7 @@ public class CombinedBattleEcNightToDay implements ICombinedBattle, ICombinedEcB
                 .setBoolean("api_opening_taisen_flag", bean::setOpeningTaisenFlag)
                 .set("api_opening_taisen", bean::setOpeningTaisen, BattleTypes.Hougeki::toHougeki)
                 .setBoolean("api_opening_flag", bean::setOpeningFlag)
-                .set("api_opening_atack", bean::setOpeningAtack, BattleTypes.OpeningAtack::toOpeningAtack)
+                .set("api_opening_atack", bean::setOpeningAtack, BattleTypes.OpeningAtackCompat::toOpeningAtackCompat)
                 .setIntegerList("api_hourai_flag", bean::setHouraiFlag)
                 .set("api_hougeki1", bean::setHougeki1, BattleTypes.Hougeki::toHougeki)
                 .set("api_hougeki2", bean::setHougeki2, BattleTypes.Hougeki::toHougeki)

--- a/src/main/java/logbook/bean/SortieBattle.java
+++ b/src/main/java/logbook/bean/SortieBattle.java
@@ -88,7 +88,7 @@ public class SortieBattle
     private Boolean openingFlag;
 
     /** api_opening_atack */
-    private BattleTypes.OpeningAtack openingAtack;
+    private BattleTypes.OpeningAtackCompat openingAtack;
 
     /** api_opening_taisen_flag */
     private Boolean openingTaisenFlag;
@@ -153,7 +153,7 @@ public class SortieBattle
                 .setInteger("api_support_flag", bean::setSupportFlag)
                 .set("api_support_info", bean::setSupportInfo, BattleTypes.SupportInfo::toSupportInfo)
                 .setBoolean("api_opening_flag", bean::setOpeningFlag)
-                .set("api_opening_atack", bean::setOpeningAtack, BattleTypes.OpeningAtack::toOpeningAtack)
+                .set("api_opening_atack", bean::setOpeningAtack, BattleTypes.OpeningAtackCompat::toOpeningAtackCompat)
                 .setBoolean("api_opening_taisen_flag", bean::setOpeningTaisenFlag)
                 .set("api_opening_taisen", bean::setOpeningTaisen, BattleTypes.Hougeki::toHougeki)
                 .setIntegerList("api_hourai_flag", bean::setHouraiFlag)

--- a/src/main/java/logbook/bean/SortieLdShooting.java
+++ b/src/main/java/logbook/bean/SortieLdShooting.java
@@ -90,7 +90,7 @@ public class SortieLdShooting
     private Boolean openingFlag;
 
     /** api_opening_atack */
-    private BattleTypes.OpeningAtack openingAtack;
+    private BattleTypes.OpeningAtackCompat openingAtack;
 
     /** api_opening_taisen_flag */
     private Boolean openingTaisenFlag;
@@ -155,7 +155,7 @@ public class SortieLdShooting
                 .setInteger("api_support_flag", bean::setSupportFlag)
                 .set("api_support_info", bean::setSupportInfo, BattleTypes.SupportInfo::toSupportInfo)
                 .setBoolean("api_opening_flag", bean::setOpeningFlag)
-                .set("api_opening_atack", bean::setOpeningAtack, BattleTypes.OpeningAtack::toOpeningAtack)
+                .set("api_opening_atack", bean::setOpeningAtack, BattleTypes.OpeningAtackCompat::toOpeningAtackCompat)
                 .setBoolean("api_opening_taisen_flag", bean::setOpeningTaisenFlag)
                 .set("api_opening_taisen", bean::setOpeningTaisen, BattleTypes.Hougeki::toHougeki)
                 .setIntegerList("api_hourai_flag", bean::setHouraiFlag)

--- a/src/main/java/logbook/internal/PhaseState.java
+++ b/src/main/java/logbook/internal/PhaseState.java
@@ -892,8 +892,7 @@ public class PhaseState {
             Chara attacker = Math.max(attackerFleet.size(), 6) > i
                     ? attackerFleet.get(i)
                     : attackerFleetCombined.get(i - 6);
-            // NOTE: indexの要素数が複数のとき、常に index[0] == index[1] であることが確認できたら
-            // ループでなくaddDetail()でまとめて追加すべきかもしれない
+            // 特四式内火艇x2積みの場合に2回攻撃が発生し、それぞれターゲットが異なる
             for (int j = 0; j < index.size(); j++) {
                 Chara defender = Math.max(defenderFleet.size(), 6) > index.get(j)
                         ? defenderFleet.get(index.get(j))

--- a/src/main/java/logbook/internal/PhaseState.java
+++ b/src/main/java/logbook/internal/PhaseState.java
@@ -34,7 +34,6 @@ import logbook.bean.BattleTypes.ISupport;
 import logbook.bean.BattleTypes.Kouku;
 import logbook.bean.BattleTypes.MidnightHougeki;
 import logbook.bean.BattleTypes.MidnightSpList;
-import logbook.bean.BattleTypes.Raigeki;
 import logbook.bean.BattleTypes.SortieAtType;
 import logbook.bean.BattleTypes.SortieAtTypeRaigeki;
 import logbook.bean.BattleTypes.Stage3;
@@ -245,7 +244,7 @@ public class PhaseState {
         // 先制対潜攻撃
         this.applyHougeki(battle.getOpeningTaisen());
         // 開幕攻撃
-        this.applyOpeningAtack(battle.getOpeningAtack());
+        this.applyOpeningAtackCompat(battle.getOpeningAtack());
         if (!this.combined && battle.isICombinedEcBattle()) {
             // 1巡目
             this.applyHougeki(battle.getHougeki1());
@@ -517,14 +516,13 @@ public class PhaseState {
      *
      * @param openingAtack 開幕攻撃フェイズ
      */
-    private void applyOpeningAtack(BattleTypes.OpeningAtack openingAtack) {
-        if (openingAtack == null) {
-            return;
-        }
-        if (openingAtack.isOpeningAtackV2()) {
-            this.applyOpeningAtackV2(openingAtack.asOpeningAtackV2());
-        } else if (openingAtack.isRaigeki()) {
-            this.applyRaigeki(openingAtack.asRaigeki());
+    private void applyOpeningAtackCompat(BattleTypes.OpeningAtackCompat openingAtack) {
+        if (openingAtack != null) {
+            if (openingAtack.isOpeningAtack()) {
+                this.applyOpeningAtack(openingAtack);
+            } else if (openingAtack.isRaigeki()) {
+                this.applyRaigeki(openingAtack);
+            }
         }
     }
 
@@ -533,15 +531,14 @@ public class PhaseState {
      *
      * @param openingAtack 開幕攻撃フェイズ
      */
-    private void applyOpeningAtackV2(BattleTypes.OpeningAtackV2 openingAtack) {
-        if (openingAtack == null) {
-            return;
+    private void applyOpeningAtack(BattleTypes.IOpeningAtack openingAtack) {
+        if (openingAtack != null) {
+            this.addDetailOpeningAtack(openingAtack);
+            // 味方
+            this.applyFriendDamage(openingAtack.getFdam());
+            // 敵
+            this.applyEnemyDamage(openingAtack.getEdam());
         }
-        this.addDetailOpeningAtack(openingAtack);
-        // 味方
-        this.applyFriendDamage(openingAtack.getFdam());
-        // 敵
-        this.applyEnemyDamage(openingAtack.getEdam());
     }
 
     /**
@@ -549,15 +546,14 @@ public class PhaseState {
      * 
      * @param raigeki 雷撃戦フェイズ
      */
-    private void applyRaigeki(Raigeki raigeki) {
-        if (raigeki == null) {
-            return;
+    private void applyRaigeki(BattleTypes.IRaigeki raigeki) {
+        if (raigeki != null) {
+            this.addDetailRaigeki(raigeki);
+            // 味方
+            this.applyFriendDamage(raigeki.getFdam());
+            // 敵
+            this.applyEnemyDamage(raigeki.getEdam());
         }
-        this.addDetailRaigeki(raigeki);
-        // 新API
-        this.applyFriendDamage(raigeki.getFdam());
-        // 敵
-        this.applyEnemyDamage(raigeki.getEdam());
     }
 
     /**
@@ -856,7 +852,7 @@ public class PhaseState {
      *
      * @param openingAtack
      */
-    private void addDetailOpeningAtack(BattleTypes.OpeningAtackV2 openingAtack) {
+    private void addDetailOpeningAtack(BattleTypes.IOpeningAtack openingAtack) {
         // 敵→味方
         this.addDetailOpeningAtack0(this.afterEnemy, this.afterEnemyCombined, this.afterFriend,
                 this.afterFriendCombined,
@@ -919,7 +915,7 @@ public class PhaseState {
      *
      * @param raigeki
      */
-    private void addDetailRaigeki(Raigeki raigeki) {
+    private void addDetailRaigeki(BattleTypes.IRaigeki raigeki) {
         // 敵→味方
         this.addDetailRaigeki0(this.afterEnemy, this.afterEnemyCombined, this.afterFriend,
                 this.afterFriendCombined,

--- a/src/main/java/logbook/internal/SeaAreaBanner.java
+++ b/src/main/java/logbook/internal/SeaAreaBanner.java
@@ -35,10 +35,13 @@ class SeaAreaBanner {
                 break;
             case 8:
             case 9:
+                bannerFormat = JOIN_BANNER_2;
+                imageNumber = area + 6;
+                break;
             case 10:
             case 11:
                 bannerFormat = JOIN_BANNER_2;
-                imageNumber = area + 4;
+                imageNumber = area + 2;
                 break;
             default:
                 return null;

--- a/src/main/java/logbook/internal/SeaAreaBanner.java
+++ b/src/main/java/logbook/internal/SeaAreaBanner.java
@@ -21,7 +21,7 @@ class SeaAreaBanner {
         String bannerFormat;
         int imageNumber;
 
-        // 2024年早春イベント暫定版
+        // 2024年早春イベント最終版
         switch (area) {
             case 1:
             case 2:

--- a/src/main/java/logbook/internal/gui/BattleDetail.java
+++ b/src/main/java/logbook/internal/gui/BattleDetail.java
@@ -23,6 +23,7 @@ import javafx.scene.image.Image;
 import javafx.scene.image.ImageView;
 import javafx.scene.layout.GridPane;
 import javafx.scene.layout.HBox;
+import javafx.scene.layout.Priority;
 import javafx.scene.layout.VBox;
 import javafx.stage.WindowEvent;
 import logbook.bean.BattleLog;
@@ -151,6 +152,10 @@ public class BattleDetail extends WindowController {
     /** 対空CI */
     @FXML
     private Label tykuCI;
+
+    /** 煙幕 */
+    @FXML
+    private Label smoke;
 
     /** 評価 */
     @FXML
@@ -334,6 +339,17 @@ public class BattleDetail extends WindowController {
                     .filter(Objects::nonNull)
                     .mapToInt(Ships::airSuperiority)
                     .sum()));
+        }
+
+        // 煙幕
+        if (this.isPractice || this.battle.getSmokeType() == null) {
+            this.smoke.setText("");
+        } else {
+            if (this.battle.getSmokeType() > 0) {
+                this.smoke.setText(this.battle.getSmokeType().toString() + "重");
+            } else {
+                this.smoke.setText("なし");
+            }
         }
 
         // 初期化

--- a/src/main/resources/logbook/gui/battle_detail.fxml
+++ b/src/main/resources/logbook/gui/battle_detail.fxml
@@ -38,7 +38,7 @@
                               <Separator />
                               <GridPane>
                                 <columnConstraints>
-                                  <ColumnConstraints hgrow="SOMETIMES" />
+                                    <ColumnConstraints hgrow="SOMETIMES" />
                                     <ColumnConstraints hgrow="SOMETIMES" minWidth="30.0" />
                                     <ColumnConstraints hgrow="SOMETIMES" maxWidth="3.0" minWidth="3.0" prefWidth="3.0" />
                                     <ColumnConstraints hgrow="SOMETIMES" />
@@ -141,9 +141,19 @@
                                           <Label text="対空CI:" />
                                        </children>
                                     </HBox>
-                                    <HBox GridPane.columnIndex="1" GridPane.columnSpan="7" GridPane.rowIndex="4">
+                                    <HBox GridPane.columnIndex="1" GridPane.columnSpan="4" GridPane.rowIndex="4">
                                        <children>
-                                          <Label fx:id="tykuCI" />
+                                          <Label fx:id="tykuCI" textOverrun="CENTER_ELLIPSIS" />
+                                       </children>
+                                    </HBox>
+                                    <HBox alignment="CENTER_RIGHT" GridPane.columnIndex="6" GridPane.rowIndex="4">
+                                       <children>
+                                          <Label text="煙幕:" />
+                                       </children>
+                                    </HBox>
+                                    <HBox alignment="CENTER_LEFT" GridPane.columnIndex="7" GridPane.rowIndex="4">
+                                       <children>
+                                          <Label fx:id="smoke" />
                                        </children>
                                     </HBox>
                                     <HBox alignment="CENTER_LEFT" GridPane.rowIndex="5">


### PR DESCRIPTION
#### 変更内容

- 24早春イベント後段海域札のズレを修正
- 開幕雷撃の内部処理をリファクタリング
- 現在の戦闘に煙幕を表示

