### PR TITLE
v24.10.1

### DIFF
--- a/pom-java17.xml
+++ b/pom-java17.xml
@@ -143,7 +143,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.2</version>
+            <version>2.18.0</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
@@ -158,12 +158,12 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.5.8</version>
+            <version>1.5.11</version>
         </dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-core</artifactId>
-            <version>1.5.8</version>
+            <version>1.5.11</version>
         </dependency>
         <dependency>
             <groupId>org.projectlombok</groupId>

--- a/pom-java17.xml
+++ b/pom-java17.xml
@@ -4,7 +4,7 @@
     <name>logbook-kai</name>
     <artifactId>logbook-kai-java17</artifactId>
     <groupId>logbook</groupId>
-    <version>24.8.1</version>
+    <version>24.9.1</version>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>

--- a/pom-java17.xml
+++ b/pom-java17.xml
@@ -82,6 +82,11 @@
                     <useSystemClassLoader>false</useSystemClassLoader>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.owasp</groupId>
+                <artifactId>dependency-check-maven</artifactId>
+                <version>11.0.0</version>
+            </plugin>
         </plugins>
     </build>
     <dependencies>

--- a/pom-java17.xml
+++ b/pom-java17.xml
@@ -93,17 +93,17 @@
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-server</artifactId>
-            <version>9.4.55.v20240627</version>
+            <version>9.4.56.v20240826</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-servlet</artifactId>
-            <version>9.4.55.v20240627</version>
+            <version>9.4.56.v20240826</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-proxy</artifactId>
-            <version>9.4.55.v20240627</version>
+            <version>9.4.56.v20240826</version>
         </dependency>
         <dependency>
             <groupId>org.openjfx</groupId>
@@ -148,22 +148,22 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>2.0.15</version>
+            <version>2.0.16</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
-            <version>2.0.15</version>
+            <version>2.0.16</version>
         </dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.5.6</version>
+            <version>1.5.8</version>
         </dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-core</artifactId>
-            <version>1.5.6</version>
+            <version>1.5.8</version>
         </dependency>
         <dependency>
             <groupId>org.projectlombok</groupId>

--- a/pom-java17.xml
+++ b/pom-java17.xml
@@ -4,7 +4,7 @@
     <name>logbook-kai</name>
     <artifactId>logbook-kai-java17</artifactId>
     <groupId>logbook</groupId>
-    <version>24.9.1</version>
+    <version>24.10.1</version>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>

--- a/pom-java17.xml
+++ b/pom-java17.xml
@@ -158,12 +158,12 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.5.11</version>
+            <version>1.5.12</version>
         </dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-core</artifactId>
-            <version>1.5.11</version>
+            <version>1.5.12</version>
         </dependency>
         <dependency>
             <groupId>org.projectlombok</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -61,6 +61,11 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.owasp</groupId>
+                <artifactId>dependency-check-maven</artifactId>
+                <version>11.0.0</version>
+            </plugin>
         </plugins>
     </build>
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -107,12 +107,12 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.5.11</version>
+            <version>1.5.12</version>
         </dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-core</artifactId>
-            <version>1.5.11</version>
+            <version>1.5.12</version>
         </dependency>
         <dependency>
             <groupId>org.projectlombok</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -92,7 +92,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.2</version>
+            <version>2.18.0</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
@@ -107,12 +107,12 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.5.8</version>
+            <version>1.5.11</version>
         </dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-core</artifactId>
-            <version>1.5.8</version>
+            <version>1.5.11</version>
         </dependency>
         <dependency>
             <groupId>org.projectlombok</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <name>logbook-kai</name>
     <artifactId>logbook-kai</artifactId>
     <groupId>logbook</groupId>
-    <version>24.8.1</version>
+    <version>24.9.1</version>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>1.8</java.version>

--- a/pom.xml
+++ b/pom.xml
@@ -72,17 +72,17 @@
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-server</artifactId>
-            <version>9.4.55.v20240627</version>
+            <version>9.4.56.v20240826</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-servlet</artifactId>
-            <version>9.4.55.v20240627</version>
+            <version>9.4.56.v20240826</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.jetty</groupId>
             <artifactId>jetty-proxy</artifactId>
-            <version>9.4.55.v20240627</version>
+            <version>9.4.56.v20240826</version>
         </dependency>
         <dependency>
             <groupId>org.controlsfx</groupId>
@@ -97,22 +97,22 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>2.0.15</version>
+            <version>2.0.16</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
-            <version>2.0.15</version>
+            <version>2.0.16</version>
         </dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.5.6</version>
+            <version>1.5.8</version>
         </dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-core</artifactId>
-            <version>1.5.6</version>
+            <version>1.5.8</version>
         </dependency>
         <dependency>
             <groupId>org.projectlombok</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <name>logbook-kai</name>
     <artifactId>logbook-kai</artifactId>
     <groupId>logbook</groupId>
-    <version>24.9.1</version>
+    <version>24.10.1</version>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>1.8</java.version>

--- a/src/main/java/logbook/internal/SeaAreaBanner.java
+++ b/src/main/java/logbook/internal/SeaAreaBanner.java
@@ -16,6 +16,10 @@ class SeaAreaBanner {
      * @return 出撃札の画像パス。存在しない場合はnull
      */
     static Path getJoinBannerPath(int area) {
+        if (area < 1) {
+            return null;
+        }
+
         // 2024年夏イベント後段作戦まで
         int imageNumber = 2 + area * 2;
 

--- a/src/main/java/logbook/internal/SeaAreaBanner.java
+++ b/src/main/java/logbook/internal/SeaAreaBanner.java
@@ -7,9 +7,7 @@ import java.nio.file.Paths;
  * 出撃札
  */
 class SeaAreaBanner {
-    private static final String JOIN_BANNER = "sally_strategymap/sally_strategymap_{0}.png";
-    private static final String JOIN_BANNER_2 = "sally_strategymap_second/sally_strategymap_second_{0}.png";
-    private static final String JOIN_BANNER_3 = "sally_strategymap_third/sally_strategymap_third_{0}.png";
+    private static final String COMMON_EVENT = "common_event";
 
     /**
      * 出撃札の画像パスを取得します
@@ -18,37 +16,9 @@ class SeaAreaBanner {
      * @return 出撃札の画像パス。存在しない場合はnull
      */
     static Path getJoinBannerPath(int area) {
-        String bannerFormat;
-        int imageNumber;
-
         // 2024年夏イベント後段作戦まで
-        switch (area) {
-            case 1:
-            case 2:
-            case 3:
-            case 4:
-                bannerFormat = JOIN_BANNER;
-                imageNumber = area + 25;
-                break;
-            case 5:
-            case 6:
-            case 7:
-            case 8:
-            case 9:
-                bannerFormat = JOIN_BANNER_2;
-                imageNumber = area + 12;
-                break;
-            /*
-            case 10:
-            case 11:
-                bannerFormat = JOIN_BANNER_2;
-                imageNumber = area + 2;
-                break;
-             */
-            default:
-                return null;
-        }
+        int imageNumber = 2 + area * 2;
 
-        return Paths.get("sally", bannerFormat.replace("{0}", Integer.toString(imageNumber)));
+        return Paths.get("common", COMMON_EVENT, String.format("%s_%d.png", COMMON_EVENT, imageNumber));
     }
 }

--- a/src/main/java/logbook/internal/Ships.java
+++ b/src/main/java/logbook/internal/Ships.java
@@ -142,10 +142,16 @@ public class Ships {
         // 改修係数
         // 小型電探：1.25
         LV_COEFFICIENT.put(SlotItemType.小型電探, 1.25D);
-        // 大型電探：1.25
-        LV_COEFFICIENT.put(SlotItemType.大型電探, 1.25D);
+        // 大型電探：1.4
+        LV_COEFFICIENT.put(SlotItemType.大型電探, 1.4D);
         // 水上偵察機：1.2
         LV_COEFFICIENT.put(SlotItemType.水上偵察機, 1.2D);
+        // 水上爆撃機 1.15
+        LV_COEFFICIENT.put(SlotItemType.水上爆撃機, 1.15D);
+        // 艦上偵察機 1.2
+        LV_COEFFICIENT.put(SlotItemType.艦上偵察機, 1.2D);
+        // 大型飛行艇 1.2
+        LV_COEFFICIENT.put(SlotItemType.大型飛行艇, 1.2D);
 
         // 対空係数
         // 対空機銃：6


### PR DESCRIPTION
This pull request includes several updates to dependencies and some refactoring in the codebase. The most important changes involve updating dependency versions, adding a new plugin, and refactoring specific classes for better maintainability.

### Dependency Updates:
* `pom-java17.xml` and `pom.xml`: Updated multiple dependency versions including `logbook-kai`, `jetty-server`, `jetty-servlet`, `jetty-proxy`, `jackson-databind`, `slf4j-api`, `slf4j-simple`, `logback-classic`, and `logback-core`. [[1]](diffhunk://#diff-0ae1353911200fa962fff6853226e26f68fa8c25af3329cdff6a025e5fac2553L7-R7) [[2]](diffhunk://#diff-0ae1353911200fa962fff6853226e26f68fa8c25af3329cdff6a025e5fac2553L96-R111) [[3]](diffhunk://#diff-0ae1353911200fa962fff6853226e26f68fa8c25af3329cdff6a025e5fac2553L146-R171) [[4]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L7-R7) [[5]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L75-R90) [[6]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L95-R120)

* `pom-java17.xml` and `pom.xml`: Added `dependency-check-maven` plugin for OWASP dependency checking. [[1]](diffhunk://#diff-0ae1353911200fa962fff6853226e26f68fa8c25af3329cdff6a025e5fac2553R85-R89) [[2]](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8R64-R68)

### Code Refactoring:
* [`src/main/java/logbook/internal/SeaAreaBanner.java`](diffhunk://#diff-7d9bdcb69736c0246f5ab1526717dfd95d6438dcb71a80d8477aff87b5d139acL10-R10): Simplified the `getJoinBannerPath` method by removing multiple constants and switch cases, and using a common event path format. [[1]](diffhunk://#diff-7d9bdcb69736c0246f5ab1526717dfd95d6438dcb71a80d8477aff87b5d139acL10-R10) [[2]](diffhunk://#diff-7d9bdcb69736c0246f5ab1526717dfd95d6438dcb71a80d8477aff87b5d139acL21-R26)

* [`src/main/java/logbook/internal/Ships.java`](diffhunk://#diff-991c27908faf655346c1c5d7ee81bad8eba61cc5f54250d813430ab4233dec83L145-R154): Updated the level coefficient values for `大型電探` and added new coefficients for `水上爆撃機`, `艦上偵察機`, and `大型飛行艇`.