### PR TITLE
Jetty 12に更新

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,8 +7,8 @@ ch-qos-logback-logback-core = "1.5.16"
 com-fasterxml-jackson-core-jackson-databind = "2.18.2"
 junit-junit = "4.13.2"
 org-controlsfx-controlsfx = "11.2.1"
-org-eclipse-jetty-jetty-server = "11.0.24"
-org-eclipse-jetty-jetty-servlet = "11.0.24"
+org-eclipse-jetty-jetty-server = "12.0.16"
+org-eclipse-jetty-jetty-servlet = "12.0.16"
 org-glassfish-javax-json = "1.1.4"
 org-openjdk-nashorn-nashorn-core = "15.6"
 org-openjfx-javafx-controls = "21.0.6"
@@ -27,7 +27,7 @@ com-fasterxml-jackson-core-jackson-databind = { module = "com.fasterxml.jackson.
 junit-junit = { module = "junit:junit", version.ref = "junit-junit" }
 org-controlsfx-controlsfx = { module = "org.controlsfx:controlsfx", version.ref = "org-controlsfx-controlsfx" }
 org-eclipse-jetty-jetty-server = { module = "org.eclipse.jetty:jetty-server", version.ref = "org-eclipse-jetty-jetty-server" }
-org-eclipse-jetty-jetty-servlet = { module = "org.eclipse.jetty:jetty-servlet", version.ref = "org-eclipse-jetty-jetty-servlet" }
+org-eclipse-jetty-jetty-servlet = { module = "org.eclipse.jetty.ee10:jetty-ee10-servlet", version.ref = "org-eclipse-jetty-jetty-servlet" }
 org-glassfish-javax-json = { module = "org.glassfish:javax.json", version.ref = "org-glassfish-javax-json" }
 org-openjdk-nashorn-nashorn-core = { module = "org.openjdk.nashorn:nashorn-core", version.ref = "org-openjdk-nashorn-nashorn-core" }
 org-openjfx-javafx-controls = { module = "org.openjfx:javafx-controls", version.ref = "org-openjfx-javafx-controls" }

--- a/src/main/java/logbook/internal/proxy/ProxyServerImpl.java
+++ b/src/main/java/logbook/internal/proxy/ProxyServerImpl.java
@@ -1,15 +1,5 @@
 package logbook.internal.proxy;
 
-import java.io.PrintWriter;
-import java.io.StringWriter;
-import java.net.BindException;
-
-import org.eclipse.jetty.server.Connector;
-import org.eclipse.jetty.server.Server;
-import org.eclipse.jetty.server.ServerConnector;
-import org.eclipse.jetty.servlet.ServletContextHandler;
-import org.eclipse.jetty.servlet.ServletHolder;
-
 import javafx.application.Platform;
 import javafx.scene.control.Alert;
 import javafx.scene.control.Alert.AlertType;
@@ -19,6 +9,15 @@ import logbook.bean.AppConfig;
 import logbook.internal.LoggerHolder;
 import logbook.internal.gui.InternalFXMLLoader;
 import logbook.proxy.ProxyServerSpi;
+import org.eclipse.jetty.ee10.servlet.ServletContextHandler;
+import org.eclipse.jetty.ee10.servlet.ServletHolder;
+import org.eclipse.jetty.server.Connector;
+import org.eclipse.jetty.server.Server;
+import org.eclipse.jetty.server.ServerConnector;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.net.BindException;
 
 /**
  * HTTPサーバーです。


### PR DESCRIPTION
parent: #26 

パッシブモード専用になったことでプロキシ周りのコード修正が不要になり、依存関係の変更のみで単純にアップグレード可能になった。

#### 変更内容

- Jetty 11 -> 12 に依存ライブラリをアップグレード
