### PR TITLE
v25.5.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <name>logbook-kai</name>
     <artifactId>logbook-kai</artifactId>
     <groupId>logbook</groupId>
-    <version>25.4.1</version>
+    <version>25.5.1</version>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>1.8</java.version>

--- a/src/main/java/logbook/internal/ExpTable.java
+++ b/src/main/java/logbook/internal/ExpTable.java
@@ -196,6 +196,11 @@ public class ExpTable {
         EXP_TABLE.put(178, 11600000);
         EXP_TABLE.put(179, 12100000);
         EXP_TABLE.put(180, 13000000);
+        EXP_TABLE.put(181, 13200000);
+        EXP_TABLE.put(182, 13600000);
+        EXP_TABLE.put(183, 14200000);
+        EXP_TABLE.put(184, 15000000);
+        EXP_TABLE.put(185, 16000000);
     }
 
     /**
@@ -213,6 +218,6 @@ public class ExpTable {
      * @return 最大Lv
      */
     public static int maxLv() {
-        return 180;
+        return 185;
     }
 }

--- a/src/main/resources/logbook/supplemental/ships.json
+++ b/src/main/resources/logbook/supplemental/ships.json
@@ -760,6 +760,7 @@
     { "id": 939, "name": "UIT-24", "min_taisen": 0, "min_kaihi": 21, "min_sakuteki": 9 },
     { "id": 940, "name": "伊503", "min_taisen": 0, "min_kaihi": 23, "min_sakuteki": 10 },
     { "id": 941, "name": "Heywood L.E.", "min_taisen": 49, "min_kaihi": 43, "min_sakuteki": 20 },
+    { "id": 942, "name": "Richard P.Leary", "min_taisen": 49, "min_kaihi": 43, "min_sakuteki": 20 },
     { "id": 943, "name": "熊野丸", "min_taisen": 22, "min_kaihi": 14, "min_sakuteki": 13 },
     { "id": 944, "name": "平安丸", "min_taisen": 0, "min_kaihi": 14, "min_sakuteki": 11 },
     { "id": 945, "name": "第百一号輸送艦", "min_taisen": 0, "min_kaihi": 29, "min_sakuteki": 2 },
@@ -791,6 +792,7 @@
     { "id": 977, "name": "伊41改", "min_taisen": 0, "min_kaihi": 14, "min_sakuteki": 11 },
     { "id": 979, "name": "稲木改二", "min_taisen": 47, "min_kaihi": 47, "min_sakuteki": 5 },
     { "id": 981, "name": "藤波改二", "min_taisen": 29, "min_kaihi": 47, "min_sakuteki": 12 },
+    { "id": 983, "name": "浜波改二", "min_taisen": 30, "min_kaihi": 46, "min_sakuteki": 10 },
     { "id": 984, "name": "Wahoo", "min_taisen": 0, "min_kaihi": 17, "min_sakuteki": 12 },
     { "id": 986, "name": "白雪改二", "min_taisen": 26, "min_kaihi": 49, "min_sakuteki": 13 },
     { "id": 987, "name": "初雪改二", "min_taisen": 27, "min_kaihi": 48, "min_sakuteki": 14 },
@@ -799,9 +801,11 @@
     { "id": 994, "name": "榧", "min_taisen": 27, "min_kaihi": 30, "min_sakuteki": 8 },
     { "id": 995, "name": "大泊", "min_taisen": 12, "min_kaihi": 14, "min_sakuteki": 7 },
     { "id": 997, "name": "杉改", "min_taisen": 52, "min_kaihi": 55, "min_sakuteki": 30 },
+    { "id": 1000, "name": "大泊改", "min_taisen": 14, "min_kaihi": 18, "min_sakuteki": 8 },
     { "id": 1001, "name": "Киров", "min_taisen": 15, "min_kaihi": 32, "min_sakuteki": 13 },
     { "id": 1003, "name": "しまね丸", "min_taisen": 24, "min_kaihi": 14, "min_sakuteki": 13 },
     { "id": 1005, "name": "Minneapolis", "min_taisen": 0, "min_kaihi": 33, "min_sakuteki": 15 },
+    { "id": 1006, "name": "Киров改", "min_taisen": 26, "min_kaihi": 39, "min_sakuteki": 14 },
     { "id": 1496, "name": "Colorado改", "min_taisen": 0, "min_kaihi": 22, "min_sakuteki": 16 }
   ]
 }


### PR DESCRIPTION
This pull request includes updates to the versioning, experience table, and ship data in the project. The most important changes involve upgrading the project version, extending the experience table to support higher levels, and adding new ship entries to the supplemental JSON file.

### Version Update:
* Updated the project version in `pom.xml` from `25.4.1` to `25.5.1` to reflect the latest release.

### Experience Table Enhancements:
* Added experience values for levels 181 to 185 in `ExpTable`.
* Updated the `maxLv` method to return `185` instead of `180`, aligning with the new maximum level.

### Ship Data Additions:
* Added new ship entries to `ships.json`, including:
  - `Richard P.Leary` (id: 942)
  - `浜波改二` (id: 983)
  - `大泊改` (id: 1000)
  - `Киров改` (id: 1006)