### PR TITLE
fix: 野埼タイマーの更新条件を修正

### DIFF
--- a/src/main/java/logbook/api/ApiReqHenseiChange.java
+++ b/src/main/java/logbook/api/ApiReqHenseiChange.java
@@ -23,63 +23,65 @@ public class ApiReqHenseiChange implements APIListenerSpi {
 
     @Override
     public void accept(JsonObject json, RequestMetaData req, ResponseMetaData res) {
-
         // 変化した艦隊
-        Set<Integer> changed = new HashSet<>();
+        final Set<Integer> changed = new HashSet<>();
 
-        Map<Integer, DeckPort> deckMap = DeckPortCollection.get()
+        final Map<Integer, DeckPort> deckMap = DeckPortCollection.get()
                 .getDeckPortMap();
 
-        Integer portId = Integer.valueOf(req.getParameter("api_id"));
-        Integer shipId = Integer.valueOf(req.getParameter("api_ship_id"));
+        final Integer deckId = Integer.valueOf(req.getParameter("api_id"));
+        final Integer shipId = Integer.valueOf(req.getParameter("api_ship_id"));
         int shipIdx = Integer.parseInt(req.getParameter("api_ship_idx"));
 
-        DeckPort deckPort = deckMap.get(portId)
-                .clone();
-        List<Integer> ships = new ArrayList<>(deckPort.getShip());
-        deckPort.setShip(ships);
-        deckMap.put(portId, deckPort);
+        final DeckPort deck = deckMap.get(deckId).clone();
+        final List<Integer> ships = new ArrayList<>(deck.getShip());
+        deck.setShip(ships);
+        deckMap.put(deckId, deck);
 
         if (shipId == -1) {
+            // はずす
             ships.remove(shipIdx);
             ships.add(-1);
         } else if (shipId == -2) {
+            // 随伴艦一括解除
             Integer first = ships.getFirst();
             ships.replaceAll(ship -> first.equals(ship) ? ship : -1);
         } else {
+            // 追加 or 移動 or 入れ替え
             Integer from = ships.get(shipIdx);
-            for (Entry<Integer, DeckPort> entry : deckMap.entrySet()) {
-                if (entry.getValue().getShip().contains(shipId)) {
-                    DeckPort port2 = entry.getValue().clone();
-                    List<Integer> ships2 = new ArrayList<>(port2.getShip());
-                    port2.setShip(ships2);
-                    deckMap.put(port2.getId(), port2);
-
+            for (Entry<Integer, DeckPort> deckEntry : deckMap.entrySet()) {
+                if (deckEntry.getValue().getShip().contains(shipId)) {
+                    DeckPort deck2 = deckEntry.getValue().clone();
+                    List<Integer> ships2 = new ArrayList<>(deck2.getShip());
+                    deck2.setShip(ships2);
+                    deckMap.put(deck2.getId(), deck2);
                     if (from == -1) {
+                        // 移動
                         ships2.removeIf(id -> id.equals(shipId));
                         ships2.add(-1);
-                        shipIdx = deckMap.get(portId).getShip().indexOf(-1);
+                        shipIdx = deckMap.get(deckId).getShip().indexOf(-1);
                     } else {
+                        // 入れ替え
                         ships2.set(ships2.indexOf(shipId), from);
                     }
-                    changed.add(port2.getId());
+                    changed.add(deck2.getId());
                     break;
                 }
             }
-            deckMap.get(portId).getShip().set(shipIdx, shipId);
+            deckMap.get(deckId).getShip().set(shipIdx, shipId);
         }
-        changed.add(portId);
+        changed.add(deckId);
 
         // 随伴艦一括解除以外の場合
         if (shipId != -2) {
             // 変化した艦隊の旗艦に工作艦が存在する場合は泊地修理タイマーをセットする
             for (Integer port : changed) {
-                List<Integer> changedShips = deckMap.get(port).getShip();
+                final List<Integer> changedShips = deckMap.get(port).getShip();
                 if (!changedShips.isEmpty()) {
-                    Integer shipid = changedShips.getFirst();
-                    Ship ship = ShipCollection.get().getShipMap().get(shipid);
+                    final Integer candidateShipId = changedShips.getFirst();
+                    final Ship ship = ShipCollection.get().getShipMap().get(candidateShipId);
                     if (ship != null) {
-                        String type = Ships.stype(ship).map(Stype::getName).orElse("");
+                        final String type = Ships.stype(ship).map(Stype::getName).orElse("");
                         if ("工作艦".equals(type)) {
                             AppCondition.get().setAkashiTimer(System.currentTimeMillis());
                             break;
@@ -89,14 +91,14 @@ public class ApiReqHenseiChange implements APIListenerSpi {
             }
             // 変化した艦隊の旗艦または2番艦に給糧艦が存在する場合は給糧艦タイマーをセットする
             for (Integer port : changed) {
-                List<Integer> changedShips = deckMap.get(port).getShip();
+                final List<Integer> changedShips = deckMap.get(port).getShip();
                 if (!changedShips.isEmpty()) {
                     boolean timerHasChanged = false;
-                    for (int index = 0; index < Math.max(changedShips.size(), 2); index++) {
-                        Integer shipid = changedShips.get(index);
-                        Ship ship = ShipCollection.get().getShipMap().get(shipid);
+                    for (int index = 0; index < Math.min(changedShips.size(), 2); index++) {
+                        final Integer candidateShipId = changedShips.get(index);
+                        final Ship ship = ShipCollection.get().getShipMap().get(candidateShipId);
                         if (ship != null) {
-                            ShipMst shipMst = ShipMstCollection.get().getShipMap().get(ship.getShipId());
+                            final ShipMst shipMst = ShipMstCollection.get().getShipMap().get(ship.getShipId());
                             if (shipMst.getName().startsWith("野埼")) {
                                 AppCondition.get().setNosakiTimer(System.currentTimeMillis());
                                 timerHasChanged = true;
@@ -111,5 +113,4 @@ public class ApiReqHenseiChange implements APIListenerSpi {
             }
         }
     }
-
 }


### PR DESCRIPTION
## 概要

野埼タイマーの更新条件に存在したバグを修正し、コードの可読性を向上させました。

## 修正内容

### バグ修正

- **野埼タイマー更新時のループ範囲を修正**
  - `Math.max(changedShips.size(), 2)` → `Math.min(changedShips.size(), 2)` に修正
  - 旗艦と2番艦のみをチェックすべきところ、`max` を使用していたため、艦隊の艦数が2隻未満の場合にインデックス範囲外エラーが発生する可能性がありました
  - 正しく最初の2隻（旗艦と2番艦）のみをチェックするように修正

### コードの改善

- 変数名を明確化