### PR TITLE
refactor: I/O待ちスレッドに仮想スレッドを使用するように変更

### DIFF
--- a/src/main/java/logbook/internal/Launcher.java
+++ b/src/main/java/logbook/internal/Launcher.java
@@ -7,7 +7,6 @@ import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
-import java.util.concurrent.ScheduledExecutorService;
 import java.util.stream.Collectors;
 
 import logbook.bean.AppConfig;
@@ -97,8 +96,8 @@ public final class Launcher {
      * スレッドプールの終了処理
      */
     private void exitLocalThreadPool() {
-        ScheduledExecutorService executor = ThreadManager.getExecutorService();
-        executor.shutdownNow();
+        ThreadManager.getScheduledExecutorService().shutdownNow();
+        ThreadManager.getExecutorService().shutdownNow();
     }
 
     /**

--- a/src/main/java/logbook/internal/ThreadManager.java
+++ b/src/main/java/logbook/internal/ThreadManager.java
@@ -1,5 +1,6 @@
 package logbook.internal;
 
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 
@@ -12,6 +13,9 @@ public final class ThreadManager {
     /** Executor */
     private static final ScheduledExecutorService EXECUTOR = Executors.newScheduledThreadPool(4);
 
+    /** Virtual Thread Executor */
+    private static final ExecutorService VIRTUAL_EXECUTOR = Executors.newVirtualThreadPerTaskExecutor();
+
     /**
      * アプリケーションで共有するExecutorService
      * <p>
@@ -20,7 +24,16 @@ public final class ThreadManager {
      *
      * @return ExecutorService
      */
-    public static ScheduledExecutorService getExecutorService() {
+    public static ExecutorService getExecutorService() {
+        return VIRTUAL_EXECUTOR;
+    }
+
+    /**
+     * スケジューリングが必要な場合に使用するExecutorService
+     *
+     * @return ScheduledExecutorService
+     */
+    public static ScheduledExecutorService getScheduledExecutorService() {
         return EXECUTOR;
     }
 }


### PR DESCRIPTION
従来の `ScheduledExecutorService` も残してはいるが、現状では使っていない。
何か問題があったときに部分的に利用するために残してある。