### PR TITLE
v26.7.2

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,7 +2,7 @@ import kotlin.text.Regex.Companion.escape
 
 group = "logbook"
 description = "logbook-kai"
-version = "26.7.1"
+version = "26.7.2"
 
 // UpgradeCode (GUID) for Windows Installer
 val windowsUpgradeUUID = "880e4493-20fc-4c89-8c5b-01e4b2479b77"

--- a/src/main/java/logbook/internal/SeaAreaBanner.java
+++ b/src/main/java/logbook/internal/SeaAreaBanner.java
@@ -9,7 +9,7 @@ import java.nio.file.Paths;
 final class SeaAreaBanner {
     private static final String COMMON_EVENT = "common_event";
 
-    private static final int IMAGE_NUMBER_BASE_OFFSET = 12;
+    private static final int IMAGE_NUMBER_BASE_OFFSET = 2;
     private static final int IMAGE_NUMBER_MULTIPLIER = 2;
     private static final int MAX_SEA_AREA_NUMBER = 14;
 
@@ -24,6 +24,8 @@ final class SeaAreaBanner {
             return null;
         }
 
+        final int imageNumber =  IMAGE_NUMBER_BASE_OFFSET + area * IMAGE_NUMBER_MULTIPLIER;
+        /*
         // 2025年秋イベント後段作戦バージョン
         // 不規則な番号に対しては定数化も行わない
         final int imageNumber = switch (area) {
@@ -36,6 +38,7 @@ final class SeaAreaBanner {
             // 札2~9 -> 16, 18, ..., 28, 30
             default -> IMAGE_NUMBER_BASE_OFFSET + area * IMAGE_NUMBER_MULTIPLIER;
         };
+         */
 
         return Paths.get("common", COMMON_EVENT, String.format("%s_%d.png", COMMON_EVENT, imageNumber));
     }

--- a/src/main/java/logbook/internal/Ships.java
+++ b/src/main/java/logbook/internal/Ships.java
@@ -617,7 +617,7 @@ public class Ships {
     private static boolean supportsAirSuperiority(SlotitemMst itemMst) {
         // 制空状態に関係するのは対空値を持つ艦戦、艦攻、艦爆、水爆、水戦、噴式機のみ
         if (itemMst.is(SlotItemType.艦上戦闘機, SlotItemType.艦上攻撃機, SlotItemType.艦上爆撃機, SlotItemType.水上爆撃機,
-                SlotItemType.水上戦闘機, SlotItemType.噴式戦闘爆撃機, SlotItemType.噴式戦闘爆撃機II)) {
+                SlotItemType.水上戦闘機, SlotItemType.噴式戦闘機, SlotItemType.噴式戦闘爆撃機, SlotItemType.噴式戦闘爆撃機II)) {
             return true;
         }
 
@@ -645,7 +645,7 @@ public class Ships {
      */
     public static double airSuperiorityTykuAdditional(SlotitemMst itemMst, SlotItem item) {
         // TODO: 対潜哨戒機仕様の隼の改修が反映されるかどうか
-        if (itemMst.is(SlotItemType.艦上戦闘機, SlotItemType.水上戦闘機, SlotItemType.局地戦闘機)) {
+        if (itemMst.is(SlotItemType.艦上戦闘機, SlotItemType.水上戦闘機, SlotItemType.局地戦闘機, SlotItemType.噴式戦闘機)) {
             return Optional.ofNullable(item.getLevel())
                     .map(level -> 0.2D * level)
                     .orElse(0D);
@@ -673,7 +673,7 @@ public class Ships {
             // 熟練ボーナス
             double bonus = Math.sqrt(skillLevel(item.getAlv()) / 10D);
             // 制空ボーナス
-            if (itemMst.is(SlotItemType.艦上戦闘機, SlotItemType.水上戦闘機, SlotItemType.局地戦闘機)
+            if (itemMst.is(SlotItemType.艦上戦闘機, SlotItemType.水上戦闘機, SlotItemType.局地戦闘機, SlotItemType.噴式戦闘機)
                     || supportsAirSuperiorityMpa(itemMst)) {
                 bonus += skillBonus1(item.getAlv());
             } else if (itemMst.is(SlotItemType.水上爆撃機)) {


### PR DESCRIPTION
# Pull Request 概要 (v26.7.2)

`main` ブランチから `v26.7.2` への変更点の概要です。

## 概要 (Summary)

今回のアップデートでは、主に以下の3つの変更が行われています。

1. **噴式戦闘機の制空値計算サポートの追加**
   - 噴式戦闘機が制空値計算（制空サポート判定、改修値による対空加算、熟練度ボーナス）に正しく含まれるよう修正しました。
2. **2026夏 期間限定海域の海域札への暫定対応**
   - イベント札のバナー画像ファイル番号の算出ロジックを、2026年夏イベントに対応した暫定版に変更しました。
3. **バージョンバンプ**
   - バージョンを `26.7.1` から `26.7.2` に更新しました。

---

## 変更詳細 (Detailed Changes)

### 1. 制空値計算に噴式戦闘機を含めるよう修正
- **対象ファイル**: [Ships.java](file:///Users/rsk/develop/projects/logbook-kai/src/main/java/logbook/internal/Ships.java)
- **修正内容**:
  - `supportsAirSuperiority(SlotitemMst itemMst)` に `SlotItemType.噴式戦闘機` を追加し、制空値計算の対象としました。
  - `airSuperiorityTykuAdditional(SlotitemMst itemMst, SlotItem item)` に `SlotItemType.噴式戦闘機` を追加し、改修レベルに応じた対空値加算（`0.2 * level`）が適用されるようにしました。
  - `airSuperiority(SlotItem item, int slot)` に `SlotItemType.噴式戦闘機` を追加し、熟練度（Alv）に応じた制空ボーナスが適用されるようにしました。

### 2. 2026夏 期間限定海域の海域札への暫定対応
- **対象ファイル**: [SeaAreaBanner.java](file:///Users/rsk/develop/projects/logbook-kai/src/main/java/logbook/internal/SeaAreaBanner.java)
- **修正内容**:
  - `IMAGE_NUMBER_BASE_OFFSET` を `12` から `2` に変更しました。
  - 2025年秋イベント時の不規則な画像番号に対応していた `switch` 式の個別ロジックをコメントアウトし、`IMAGE_NUMBER_BASE_OFFSET + area * IMAGE_NUMBER_MULTIPLIER` による単純な連番算出式に統一しました。

### 3. バージョンアップ
- **対象ファイル**: [build.gradle.kts](file:///Users/rsk/develop/projects/logbook-kai/build.gradle.kts)
- **修正内容**:
  - バージョン定義を `26.7.1` から `26.7.2` に変更しました。

---

## コミット履歴 (Commit History)
- `58e2f07` fix: 噴式戦闘機を制空値計算に含めるように修正
- `de2d42c` feat: 2026夏 期間限定海域の海域札に暫定対応
- `cd0e05d` chore: Version bumped to 26.7.2

